### PR TITLE
README update

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This collection assumes that the API Gateway, the ERS APIs and OpenAPIs are enab
 First, define a `credentials.yml` file where you specify your Cisco ISE credentials as ansible variables:
 ```
 ---
-ise_hostname: <A.B.C.D>
+ise_hostname: <A.B.C.D> # Default ISE ERS port 9060 may be needed, myise.example.com:9060
 ise_username: <username>
 ise_password: <password>
 ise_version: 3.0.0  # optional, defaults to 3.0.0

--- a/README.md
+++ b/README.md
@@ -32,11 +32,13 @@ ansible-galaxy collection install cisco.ise
 
 This collection assumes that the API Gateway, the ERS APIs and OpenAPIs are enabled.
 
+### See Also:
+* [DEVNET ISE API Reference](https://developer.cisco.com/docs/identity-services-engine/3.0/#!setting-up) for more details.
 ## Use
 First, define a `credentials.yml` file where you specify your Cisco ISE credentials as ansible variables:
 ```
 ---
-ise_hostname: <A.B.C.D> # Default ISE ERS port 9060 may be needed, myise.example.com:9060
+ise_hostname: <A.B.C.D>  # Default ISE ERS port 9060 may be needed, myise.example.com:9060
 ise_username: <username>
 ise_password: <password>
 ise_version: 3.0.0  # optional, defaults to 3.0.0


### PR DESCRIPTION
Added info on the ERS port 9060 to the readme and a link to the DEVNET ISE guide, since the errors you get when you don't define the port a super cryptic.

`ise_hostname: 'ise.example.com'` Results:
```
The full traceback is:
Traceback (most recent call last):
  File "/home/username/.local/lib/python3.8/site-packages/ansible/executor/task_executor.py", line 158, in run
    res = self._execute()
  File "/home/username/.local/lib/python3.8/site-packages/ansible/executor/task_executor.py", line 582, in _execute
    result = self._handler.run(task_vars=variables)
  File "/home/username/.ansible/collections/ansible_collections/cisco/ise/plugins/action/network_device_group_info.py", line 119, in run
    if isinstance(tmp_response, list):
UnboundLocalError: local variable 'tmp_response' referenced before assignment
fatal: [ise.example.com]: FAILED! => {
    "msg": "Unexpected failure during module execution.",
    "stdout": ""
}
```
Should be
`ise_hostname: 'ise.example.com:9060'`

Back to ISE ISE BABY!

![Alt Text](https://media.giphy.com/media/3oz8xz54qxEsEOlEJ2/giphy.gif)