### PR TITLE
Add new modules for Active Directory and Node Management

### DIFF
--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1644,3 +1644,22 @@ releases:
         - Fixed generator function names in network_device_group, restid_store, sponsor_group_member,
           authorization_profile, guest_user, portal_theme, sponsored_guest_portal,
           portal_global_setting, profiler_profile, and admin_user.
+  3.2.0:
+    release_date: "2026-05-07"
+    changes:
+      release_summary: >
+        Restore 16 critical modules removed in v3.0.0. All deployment,
+        node group, node services profiler, and active directory
+        sub-operation modules are back.
+      major_changes:
+        - Restored node_deployment and node_deployment_info modules.
+        - Restored node_deployment_sync module.
+        - Restored node_secondary_to_primary module.
+        - Restored node_standalone_to_primary module.
+        - Restored node_group and node_group_info modules.
+        - Restored node_group_node_info, node_group_node_create, node_group_node_delete modules.
+        - Restored node_services_profiler_probe_config and node_services_profiler_probe_config_info modules.
+        - Restored active_directory_join_domain module.
+        - Restored active_directory_leave_domain module.
+        - Restored active_directory_groups_by_domain_info module.
+        - Restored active_directory_add_groups module.

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: cisco
 name: ise
-version: 3.1.0
+version: 3.2.0
 readme: README.md
 authors:
   - Jose Bogarin <jbogarin@cloverhound.cr>

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -34,3 +34,4 @@ build_ignore:
   - Makefile
   - requirements.txt
   - cisco-ise-*.tar.gz
+  - .claude

--- a/plugins/action/active_directory_add_groups.py
+++ b/plugins/action/active_directory_add_groups.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+from ansible.plugins.action import ActionBase
+try:
+    from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
+        AnsibleArgSpecValidator,
+    )
+except ImportError:
+    ANSIBLE_UTILS_IS_INSTALLED = False
+else:
+    ANSIBLE_UTILS_IS_INSTALLED = True
+from ansible.errors import AnsibleActionFail
+from ansible_collections.cisco.ise.plugins.plugin_utils.ise import (
+    ISESDK,
+    ise_argument_spec,
+)
+
+argument_spec = ise_argument_spec()
+argument_spec.update(dict(
+    id=dict(type="str"),
+    adAttributes=dict(type="dict"),
+    adScopesNames=dict(type="str"),
+    adgroups=dict(type="dict"),
+    advancedSettings=dict(type="dict"),
+    description=dict(type="str"),
+    domain=dict(type="str"),
+    enableDomainAllowedList=dict(type="bool"),
+    ERSActiveDirectoryDomains=dict(type="dict"),
+    name=dict(type="str"),
+))
+
+required_if = []
+required_one_of = []
+mutually_exclusive = []
+required_together = []
+
+
+class ActionModule(ActionBase):
+    def __init__(self, *args, **kwargs):
+        if not ANSIBLE_UTILS_IS_INSTALLED:
+            raise AnsibleActionFail(
+                "ansible.utils is not installed. Execute 'ansible-galaxy collection install ansible.utils'"
+            )
+        super(ActionModule, self).__init__(*args, **kwargs)
+        self._supports_async = False
+        self._supports_check_mode = False
+        self._result = None
+
+    def _check_argspec(self):
+        aav = AnsibleArgSpecValidator(
+            data=self._task.args,
+            schema=dict(argument_spec=argument_spec),
+            schema_format="argspec",
+            schema_conditionals=dict(
+                required_if=required_if,
+                required_one_of=required_one_of,
+                mutually_exclusive=mutually_exclusive,
+                required_together=required_together,
+            ),
+            name=self._task.action,
+        )
+        valid, errors, self._task.args = aav.validate()
+        if not valid:
+            raise AnsibleActionFail(errors)
+
+    def run(self, tmp=None, task_vars=None):
+        self._task.diff = False
+        self._result = super(ActionModule, self).run(tmp, task_vars)
+        self._result["changed"] = False
+        self._check_argspec()
+
+        ise = ISESDK(params=self._task.args)
+        params = self._task.args
+
+        response = ise.exec(
+            family="active_directory",
+            function="update_activedirectory_addgroups_by_id",
+            params=dict(
+                id=params.get("id"),
+                ad_attributes=params.get("adAttributes"),
+                ad_scopes_names=params.get("adScopesNames"),
+                adgroups=params.get("adgroups"),
+                advanced_settings=params.get("advancedSettings"),
+                description=params.get("description"),
+                domain=params.get("domain"),
+                enable_domain_allowed_list=params.get("enableDomainAllowedList"),
+                ers_active_directory_domains=params.get("ERSActiveDirectoryDomains"),
+                name=params.get("name"),
+            ),
+        ).response
+
+        self._result.update(dict(ise_response=response))
+        self._result["changed"] = True
+        self._result.update(ise.exit_json())
+        return self._result

--- a/plugins/action/active_directory_groups_by_domain_info.py
+++ b/plugins/action/active_directory_groups_by_domain_info.py
@@ -76,7 +76,7 @@ class ActionModule(ActionBase):
                 id=params.get("id"),
                 additional_data=params.get("additionalData"),
             ),
-        ).response
+        ).response["ERSActiveDirectoryGroups"]
 
         self._result.update(dict(ise_response=response))
         self._result.update(ise.exit_json())

--- a/plugins/action/active_directory_groups_by_domain_info.py
+++ b/plugins/action/active_directory_groups_by_domain_info.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+from ansible.plugins.action import ActionBase
+try:
+    from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
+        AnsibleArgSpecValidator,
+    )
+except ImportError:
+    ANSIBLE_UTILS_IS_INSTALLED = False
+else:
+    ANSIBLE_UTILS_IS_INSTALLED = True
+from ansible.errors import AnsibleActionFail
+from ansible_collections.cisco.ise.plugins.plugin_utils.ise import (
+    ISESDK,
+    ise_argument_spec,
+)
+
+argument_spec = ise_argument_spec()
+argument_spec.update(dict(
+    id=dict(type="str"),
+    additionalData=dict(type="list", elements="dict"),
+))
+
+required_if = []
+required_one_of = []
+mutually_exclusive = []
+required_together = []
+
+
+class ActionModule(ActionBase):
+    def __init__(self, *args, **kwargs):
+        if not ANSIBLE_UTILS_IS_INSTALLED:
+            raise AnsibleActionFail(
+                "ansible.utils is not installed. Execute 'ansible-galaxy collection install ansible.utils'"
+            )
+        super(ActionModule, self).__init__(*args, **kwargs)
+        self._supports_async = False
+        self._supports_check_mode = True
+        self._result = None
+
+    def _check_argspec(self):
+        aav = AnsibleArgSpecValidator(
+            data=self._task.args,
+            schema=dict(argument_spec=argument_spec),
+            schema_format="argspec",
+            schema_conditionals=dict(
+                required_if=required_if,
+                required_one_of=required_one_of,
+                mutually_exclusive=mutually_exclusive,
+                required_together=required_together,
+            ),
+            name=self._task.action,
+        )
+        valid, errors, self._task.args = aav.validate()
+        if not valid:
+            raise AnsibleActionFail(errors)
+
+    def run(self, tmp=None, task_vars=None):
+        self._task.diff = False
+        self._result = super(ActionModule, self).run(tmp, task_vars)
+        self._result["changed"] = False
+        self._check_argspec()
+
+        ise = ISESDK(params=self._task.args)
+        params = self._task.args
+
+        response = ise.exec(
+            family="active_directory",
+            function="update_activedirectory_getgroupsbydomain_by_id",
+            params=dict(
+                id=params.get("id"),
+                additional_data=params.get("additionalData"),
+            ),
+        ).response
+
+        self._result.update(dict(ise_response=response))
+        self._result.update(ise.exit_json())
+        return self._result

--- a/plugins/action/active_directory_join_domain.py
+++ b/plugins/action/active_directory_join_domain.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+from ansible.plugins.action import ActionBase
+try:
+    from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
+        AnsibleArgSpecValidator,
+    )
+except ImportError:
+    ANSIBLE_UTILS_IS_INSTALLED = False
+else:
+    ANSIBLE_UTILS_IS_INSTALLED = True
+from ansible.errors import AnsibleActionFail
+from ansible_collections.cisco.ise.plugins.plugin_utils.ise import (
+    ISESDK,
+    ise_argument_spec,
+)
+
+argument_spec = ise_argument_spec()
+argument_spec.update(dict(
+    id=dict(type="str"),
+    adAttributes=dict(type="dict"),
+    adScopesNames=dict(type="str"),
+    adgroups=dict(type="dict"),
+    advancedSettings=dict(type="dict"),
+    description=dict(type="str"),
+    domain=dict(type="str"),
+    enableDomainAllowedList=dict(type="bool"),
+    ERSActiveDirectoryDomains=dict(type="dict"),
+    name=dict(type="str"),
+))
+
+required_if = []
+required_one_of = []
+mutually_exclusive = []
+required_together = []
+
+
+class ActionModule(ActionBase):
+    def __init__(self, *args, **kwargs):
+        if not ANSIBLE_UTILS_IS_INSTALLED:
+            raise AnsibleActionFail(
+                "ansible.utils is not installed. Execute 'ansible-galaxy collection install ansible.utils'"
+            )
+        super(ActionModule, self).__init__(*args, **kwargs)
+        self._supports_async = False
+        self._supports_check_mode = False
+        self._result = None
+
+    def _check_argspec(self):
+        aav = AnsibleArgSpecValidator(
+            data=self._task.args,
+            schema=dict(argument_spec=argument_spec),
+            schema_format="argspec",
+            schema_conditionals=dict(
+                required_if=required_if,
+                required_one_of=required_one_of,
+                mutually_exclusive=mutually_exclusive,
+                required_together=required_together,
+            ),
+            name=self._task.action,
+        )
+        valid, errors, self._task.args = aav.validate()
+        if not valid:
+            raise AnsibleActionFail(errors)
+
+    def run(self, tmp=None, task_vars=None):
+        self._task.diff = False
+        self._result = super(ActionModule, self).run(tmp, task_vars)
+        self._result["changed"] = False
+        self._check_argspec()
+
+        ise = ISESDK(params=self._task.args)
+        params = self._task.args
+
+        response = ise.exec(
+            family="active_directory",
+            function="update_activedirectory_join_by_id",
+            params=dict(
+                id=params.get("id"),
+                ad_attributes=params.get("adAttributes"),
+                ad_scopes_names=params.get("adScopesNames"),
+                adgroups=params.get("adgroups"),
+                advanced_settings=params.get("advancedSettings"),
+                description=params.get("description"),
+                domain=params.get("domain"),
+                enable_domain_allowed_list=params.get("enableDomainAllowedList"),
+                ers_active_directory_domains=params.get("ERSActiveDirectoryDomains"),
+                name=params.get("name"),
+            ),
+        ).response
+
+        self._result.update(dict(ise_response=response))
+        self._result["changed"] = True
+        self._result.update(ise.exit_json())
+        return self._result

--- a/plugins/action/active_directory_leave_domain.py
+++ b/plugins/action/active_directory_leave_domain.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+from ansible.plugins.action import ActionBase
+try:
+    from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
+        AnsibleArgSpecValidator,
+    )
+except ImportError:
+    ANSIBLE_UTILS_IS_INSTALLED = False
+else:
+    ANSIBLE_UTILS_IS_INSTALLED = True
+from ansible.errors import AnsibleActionFail
+from ansible_collections.cisco.ise.plugins.plugin_utils.ise import (
+    ISESDK,
+    ise_argument_spec,
+)
+
+argument_spec = ise_argument_spec()
+argument_spec.update(dict(
+    id=dict(type="str"),
+    adAttributes=dict(type="dict"),
+    adScopesNames=dict(type="str"),
+    adgroups=dict(type="dict"),
+    advancedSettings=dict(type="dict"),
+    description=dict(type="str"),
+    domain=dict(type="str"),
+    enableDomainAllowedList=dict(type="bool"),
+    ERSActiveDirectoryDomains=dict(type="dict"),
+    name=dict(type="str"),
+))
+
+required_if = []
+required_one_of = []
+mutually_exclusive = []
+required_together = []
+
+
+class ActionModule(ActionBase):
+    def __init__(self, *args, **kwargs):
+        if not ANSIBLE_UTILS_IS_INSTALLED:
+            raise AnsibleActionFail(
+                "ansible.utils is not installed. Execute 'ansible-galaxy collection install ansible.utils'"
+            )
+        super(ActionModule, self).__init__(*args, **kwargs)
+        self._supports_async = False
+        self._supports_check_mode = False
+        self._result = None
+
+    def _check_argspec(self):
+        aav = AnsibleArgSpecValidator(
+            data=self._task.args,
+            schema=dict(argument_spec=argument_spec),
+            schema_format="argspec",
+            schema_conditionals=dict(
+                required_if=required_if,
+                required_one_of=required_one_of,
+                mutually_exclusive=mutually_exclusive,
+                required_together=required_together,
+            ),
+            name=self._task.action,
+        )
+        valid, errors, self._task.args = aav.validate()
+        if not valid:
+            raise AnsibleActionFail(errors)
+
+    def run(self, tmp=None, task_vars=None):
+        self._task.diff = False
+        self._result = super(ActionModule, self).run(tmp, task_vars)
+        self._result["changed"] = False
+        self._check_argspec()
+
+        ise = ISESDK(params=self._task.args)
+        params = self._task.args
+
+        response = ise.exec(
+            family="active_directory",
+            function="update_activedirectory_leave_by_id",
+            params=dict(
+                id=params.get("id"),
+                ad_attributes=params.get("adAttributes"),
+                ad_scopes_names=params.get("adScopesNames"),
+                adgroups=params.get("adgroups"),
+                advanced_settings=params.get("advancedSettings"),
+                description=params.get("description"),
+                domain=params.get("domain"),
+                enable_domain_allowed_list=params.get("enableDomainAllowedList"),
+                ers_active_directory_domains=params.get("ERSActiveDirectoryDomains"),
+                name=params.get("name"),
+            ),
+        ).response
+
+        self._result.update(dict(ise_response=response))
+        self._result["changed"] = True
+        self._result.update(ise.exit_json())
+        return self._result

--- a/plugins/action/node_deployment.py
+++ b/plugins/action/node_deployment.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+from ansible.plugins.action import ActionBase
+try:
+    from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
+        AnsibleArgSpecValidator,
+    )
+except ImportError:
+    ANSIBLE_UTILS_IS_INSTALLED = False
+else:
+    ANSIBLE_UTILS_IS_INSTALLED = True
+from ansible.errors import AnsibleActionFail
+from ansible_collections.cisco.ise.plugins.plugin_utils.ise import (
+    ISESDK,
+    ise_argument_spec,
+    ise_compare_equality,
+)
+from ansible_collections.cisco.ise.plugins.plugin_utils.exceptions import (
+    InconsistentParameters,
+)
+
+argument_spec = ise_argument_spec()
+argument_spec.update(dict(
+    state=dict(type="str", default="present", choices=["present", "absent"]),
+    hostname=dict(type="str"),
+    allowCertImport=dict(type="bool"),
+    fqdn=dict(type="str"),
+    password=dict(type="str", no_log=True),
+    roles=dict(type="list", elements="str"),
+    services=dict(type="list", elements="str"),
+    userName=dict(type="str"),
+))
+
+required_if = [
+    ("state", "present", ["hostname"], False),
+    ("state", "absent", ["hostname"], False),
+]
+required_one_of = []
+mutually_exclusive = []
+required_together = []
+
+
+class NodeDeployment(object):
+    def __init__(self, params, ise):
+        self.ise = ise
+        self.new_object = dict(
+            hostname=params.get("hostname"),
+            allow_cert_import=params.get("allowCertImport"),
+            fqdn=params.get("fqdn"),
+            password=params.get("password"),
+            roles=params.get("roles"),
+            services=params.get("services"),
+            user_name=params.get("userName"),
+        )
+
+    def get_object_by_hostname(self, hostname):
+        try:
+            return self.ise.exec(
+                family="node_deployment",
+                function="get_node_details",
+                handle_func_exception=False,
+                params={"hostname": hostname},
+            ).response
+        except Exception:
+            return None
+
+    def exists(self):
+        hostname = self.new_object.get("hostname")
+        prev_obj = None
+        if hostname:
+            prev_obj = self.get_object_by_hostname(hostname)
+        it_exists = prev_obj is not None and isinstance(prev_obj, dict)
+        return (it_exists, prev_obj)
+
+    def requires_update(self, current_obj):
+        obj_params = [
+            ("roles", "roles"),
+            ("services", "services"),
+        ]
+        return any(
+            not ise_compare_equality(current_obj.get(ise_param), self.new_object.get(ansible_param))
+            for (ise_param, ansible_param) in obj_params
+        )
+
+    def create(self):
+        return self.ise.exec(
+            family="node_deployment",
+            function="register_node",
+            params=self.new_object,
+        ).response
+
+    def update(self):
+        return self.ise.exec(
+            family="node_deployment",
+            function="update_node",
+            params=self.new_object,
+        ).response
+
+    def delete(self):
+        return self.ise.exec(
+            family="node_deployment",
+            function="delete_node",
+            params={"hostname": self.new_object.get("hostname")},
+        ).response
+
+
+class ActionModule(ActionBase):
+    def __init__(self, *args, **kwargs):
+        if not ANSIBLE_UTILS_IS_INSTALLED:
+            raise AnsibleActionFail(
+                "ansible.utils is not installed. Execute 'ansible-galaxy collection install ansible.utils'"
+            )
+        super(ActionModule, self).__init__(*args, **kwargs)
+        self._supports_async = False
+        self._supports_check_mode = False
+        self._result = None
+
+    def _check_argspec(self):
+        aav = AnsibleArgSpecValidator(
+            data=self._task.args,
+            schema=dict(argument_spec=argument_spec),
+            schema_format="argspec",
+            schema_conditionals=dict(
+                required_if=required_if,
+                required_one_of=required_one_of,
+                mutually_exclusive=mutually_exclusive,
+                required_together=required_together,
+            ),
+            name=self._task.action,
+        )
+        valid, errors, self._task.args = aav.validate()
+        if not valid:
+            raise AnsibleActionFail(errors)
+
+    def run(self, tmp=None, task_vars=None):
+        self._task.diff = False
+        self._result = super(ActionModule, self).run(tmp, task_vars)
+        self._result["changed"] = False
+        self._check_argspec()
+
+        ise = ISESDK(params=self._task.args)
+        obj = NodeDeployment(self._task.args, ise)
+        state = self._task.args.get("state")
+        response = None
+
+        if state == "present":
+            (obj_exists, prev_obj) = obj.exists()
+            if obj_exists:
+                if obj.requires_update(prev_obj):
+                    ise_update_response = obj.update()
+                    self._result.update(dict(ise_update_response=ise_update_response))
+                    (_, updated_obj) = obj.exists()
+                    ise.object_updated()
+                    response = updated_obj
+                else:
+                    response = prev_obj
+                    ise.object_already_present()
+            else:
+                ise_create_response = obj.create()
+                self._result.update(dict(ise_create_response=ise_create_response))
+                (_, created_obj) = obj.exists()
+                response = created_obj
+                ise.object_created()
+        elif state == "absent":
+            (obj_exists, prev_obj) = obj.exists()
+            if obj_exists:
+                obj.delete()
+                response = prev_obj
+                ise.object_deleted()
+            else:
+                response = None
+                ise.object_already_absent()
+
+        self._result.update(dict(ise_response=response))
+        self._result.update(ise.exit_json())
+        return self._result

--- a/plugins/action/node_deployment.py
+++ b/plugins/action/node_deployment.py
@@ -19,26 +19,29 @@ from ansible_collections.cisco.ise.plugins.plugin_utils.ise import (
     ISESDK,
     ise_argument_spec,
     ise_compare_equality,
+    get_dict_result,
 )
 from ansible_collections.cisco.ise.plugins.plugin_utils.exceptions import (
     InconsistentParameters,
 )
 
 argument_spec = ise_argument_spec()
-argument_spec.update(dict(
-    state=dict(type="str", default="present", choices=["present", "absent"]),
-    hostname=dict(type="str"),
-    allowCertImport=dict(type="bool"),
-    fqdn=dict(type="str"),
-    password=dict(type="str", no_log=True),
-    roles=dict(type="list", elements="str"),
-    services=dict(type="list", elements="str"),
-    userName=dict(type="str"),
-))
+argument_spec.update(
+    dict(
+        state=dict(type="str", default="present", choices=["present", "absent"]),
+        allowCertImport=dict(type="bool"),
+        fqdn=dict(type="str"),
+        password=dict(type="str", no_log=True),
+        roles=dict(type="list", elements="str"),
+        services=dict(type="list", elements="str"),
+        userName=dict(type="str"),
+        hostname=dict(type="str"),
+    )
+)
 
 required_if = [
-    ("state", "present", ["hostname"], False),
-    ("state", "absent", ["hostname"], False),
+    ("state", "present", ["hostname"], True),
+    ("state", "absent", ["hostname"], True),
 ]
 required_one_of = []
 mutually_exclusive = []
@@ -49,64 +52,102 @@ class NodeDeployment(object):
     def __init__(self, params, ise):
         self.ise = ise
         self.new_object = dict(
-            hostname=params.get("hostname"),
             allow_cert_import=params.get("allowCertImport"),
             fqdn=params.get("fqdn"),
             password=params.get("password"),
             roles=params.get("roles"),
             services=params.get("services"),
             user_name=params.get("userName"),
+            hostname=params.get("hostname"),
         )
 
-    def get_object_by_hostname(self, hostname):
+    def get_object_by_name(self, name):
         try:
-            return self.ise.exec(
+            result = self.ise.exec(
                 family="node_deployment",
                 function="get_node_details",
+                params={"hostname": name},
                 handle_func_exception=False,
-                params={"hostname": hostname},
-            ).response
+            ).response["response"]
+            result = get_dict_result(result, "name", name)
+        except (TypeError, AttributeError) as e:
+            self.ise.fail_json(
+                msg=(
+                    "An error occured when executing operation."
+                    " Check the configuration of your API Settings and API Gateway settings on your ISE server."
+                    " This collection assumes that the API Gateway, the ERS APIs and OpenAPIs are enabled."
+                    " You may want to enable the (ise_debug: True) argument."
+                    " The error was: {error}"
+                ).format(error=e)
+            )
         except Exception:
-            return None
+            result = None
+        return result
+
+    def get_object_by_id(self, id):
+        # NOTICE: Does not have a get by id method or it is in another action
+        result = None
+        return result
 
     def exists(self):
-        hostname = self.new_object.get("hostname")
         prev_obj = None
-        if hostname:
-            prev_obj = self.get_object_by_hostname(hostname)
+        id_exists = False
+        name_exists = False
+        o_id = self.new_object.get("id")
+        name = self.new_object.get("hostname")
+        if o_id:
+            prev_obj = self.get_object_by_id(o_id)
+            id_exists = prev_obj is not None and isinstance(prev_obj, dict)
+        if not id_exists and name:
+            prev_obj = self.get_object_by_name(name)
+            name_exists = prev_obj is not None and isinstance(prev_obj, dict)
+        if name_exists:
+            _id = prev_obj.get("id")
+            if id_exists and name_exists and o_id != _id:
+                raise InconsistentParameters(
+                    "The 'id' and 'name' params don't refer to the same object"
+                )
         it_exists = prev_obj is not None and isinstance(prev_obj, dict)
         return (it_exists, prev_obj)
 
     def requires_update(self, current_obj):
+        requested_obj = self.new_object
+
         obj_params = [
+            ("allowCertImport", "allow_cert_import"),
+            ("fqdn", "fqdn"),
+            ("password", "password"),
             ("roles", "roles"),
             ("services", "services"),
+            ("userName", "user_name"),
+            ("hostname", "hostname"),
         ]
         return any(
-            not ise_compare_equality(current_obj.get(ise_param), self.new_object.get(ansible_param))
+            not ise_compare_equality(
+                current_obj.get(ise_param), requested_obj.get(ansible_param)
+            )
             for (ise_param, ansible_param) in obj_params
         )
 
     def create(self):
-        return self.ise.exec(
+        result = self.ise.exec(
             family="node_deployment",
             function="register_node",
             params=self.new_object,
         ).response
+        return result
 
     def update(self):
-        return self.ise.exec(
-            family="node_deployment",
-            function="update_node",
-            params=self.new_object,
+        result = self.ise.exec(
+            family="node_deployment", function="update_node", params=self.new_object
         ).response
+        return result
 
     def delete(self):
-        return self.ise.exec(
-            family="node_deployment",
-            function="delete_node",
-            params={"hostname": self.new_object.get("hostname")},
+        result = self.ise.exec(
+            family="node_deployment", function="delete_node", params=self.new_object
         ).response
+        return result
 
 
 class ActionModule(ActionBase):
@@ -145,7 +186,9 @@ class ActionModule(ActionBase):
 
         ise = ISESDK(params=self._task.args)
         obj = NodeDeployment(self._task.args, ise)
+
         state = self._task.args.get("state")
+
         response = None
 
         if state == "present":
@@ -154,18 +197,19 @@ class ActionModule(ActionBase):
                 if obj.requires_update(prev_obj):
                     ise_update_response = obj.update()
                     self._result.update(dict(ise_update_response=ise_update_response))
-                    (_, updated_obj) = obj.exists()
-                    ise.object_updated()
+                    (obj_exists, updated_obj) = obj.exists()
                     response = updated_obj
+                    ise.object_updated()
                 else:
                     response = prev_obj
                     ise.object_already_present()
             else:
                 ise_create_response = obj.create()
                 self._result.update(dict(ise_create_response=ise_create_response))
-                (_, created_obj) = obj.exists()
+                (obj_exists, created_obj) = obj.exists()
                 response = created_obj
                 ise.object_created()
+
         elif state == "absent":
             (obj_exists, prev_obj) = obj.exists()
             if obj_exists:
@@ -173,7 +217,6 @@ class ActionModule(ActionBase):
                 response = prev_obj
                 ise.object_deleted()
             else:
-                response = None
                 ise.object_already_absent()
 
         self._result.update(dict(ise_response=response))

--- a/plugins/action/node_deployment_info.py
+++ b/plugins/action/node_deployment_info.py
@@ -23,7 +23,7 @@ from ansible_collections.cisco.ise.plugins.plugin_utils.ise import (
 argument_spec = ise_argument_spec()
 argument_spec.update(dict(
     hostname=dict(type="str"),
-    filter=dict(type="str"),
+    filter=dict(type="list"),
     filterType=dict(type="str"),
 ))
 
@@ -82,13 +82,13 @@ class ActionModule(ActionBase):
                 family="node_deployment",
                 function="get_node_details",
                 params=self.get_object(self._task.args),
-            ).response
+            ).response["response"]
         else:
             response = ise.exec(
                 family="node_deployment",
                 function="get_deployment_nodes",
                 params=self.get_object(self._task.args),
-            ).response
+            ).response["response"]
 
         self._result.update(dict(ise_response=response))
         self._result.update(ise.exit_json())

--- a/plugins/action/node_deployment_info.py
+++ b/plugins/action/node_deployment_info.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+from ansible.plugins.action import ActionBase
+try:
+    from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
+        AnsibleArgSpecValidator,
+    )
+except ImportError:
+    ANSIBLE_UTILS_IS_INSTALLED = False
+else:
+    ANSIBLE_UTILS_IS_INSTALLED = True
+from ansible.errors import AnsibleActionFail
+from ansible_collections.cisco.ise.plugins.plugin_utils.ise import (
+    ISESDK,
+    ise_argument_spec,
+)
+
+argument_spec = ise_argument_spec()
+argument_spec.update(dict(
+    hostname=dict(type="str"),
+    filter=dict(type="str"),
+    filterType=dict(type="str"),
+))
+
+required_if = []
+required_one_of = []
+mutually_exclusive = []
+required_together = []
+
+
+class ActionModule(ActionBase):
+    def __init__(self, *args, **kwargs):
+        if not ANSIBLE_UTILS_IS_INSTALLED:
+            raise AnsibleActionFail(
+                "ansible.utils is not installed. Execute 'ansible-galaxy collection install ansible.utils'"
+            )
+        super(ActionModule, self).__init__(*args, **kwargs)
+        self._supports_async = False
+        self._supports_check_mode = True
+        self._result = None
+
+    def _check_argspec(self):
+        aav = AnsibleArgSpecValidator(
+            data=self._task.args,
+            schema=dict(argument_spec=argument_spec),
+            schema_format="argspec",
+            schema_conditionals=dict(
+                required_if=required_if,
+                required_one_of=required_one_of,
+                mutually_exclusive=mutually_exclusive,
+                required_together=required_together,
+            ),
+            name=self._task.action,
+        )
+        valid, errors, self._task.args = aav.validate()
+        if not valid:
+            raise AnsibleActionFail(errors)
+
+    def get_object(self, params):
+        return dict(
+            hostname=params.get("hostname"),
+            filter=params.get("filter"),
+            filter_type=params.get("filterType"),
+        )
+
+    def run(self, tmp=None, task_vars=None):
+        self._task.diff = False
+        self._result = super(ActionModule, self).run(tmp, task_vars)
+        self._result["changed"] = False
+        self._check_argspec()
+
+        ise = ISESDK(params=self._task.args)
+        hostname = self._task.args.get("hostname")
+
+        if hostname:
+            response = ise.exec(
+                family="node_deployment",
+                function="get_node_details",
+                params=self.get_object(self._task.args),
+            ).response
+        else:
+            response = ise.exec(
+                family="node_deployment",
+                function="get_deployment_nodes",
+                params=self.get_object(self._task.args),
+            ).response
+
+        self._result.update(dict(ise_response=response))
+        self._result.update(ise.exit_json())
+        return self._result

--- a/plugins/action/node_deployment_sync.py
+++ b/plugins/action/node_deployment_sync.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+from ansible.plugins.action import ActionBase
+try:
+    from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
+        AnsibleArgSpecValidator,
+    )
+except ImportError:
+    ANSIBLE_UTILS_IS_INSTALLED = False
+else:
+    ANSIBLE_UTILS_IS_INSTALLED = True
+from ansible.errors import AnsibleActionFail
+from ansible_collections.cisco.ise.plugins.plugin_utils.ise import (
+    ISESDK,
+    ise_argument_spec,
+)
+
+argument_spec = ise_argument_spec()
+argument_spec.update(dict(
+    hostname=dict(type="str"),
+))
+
+required_if = []
+required_one_of = []
+mutually_exclusive = []
+required_together = []
+
+
+class ActionModule(ActionBase):
+    def __init__(self, *args, **kwargs):
+        if not ANSIBLE_UTILS_IS_INSTALLED:
+            raise AnsibleActionFail(
+                "ansible.utils is not installed. Execute 'ansible-galaxy collection install ansible.utils'"
+            )
+        super(ActionModule, self).__init__(*args, **kwargs)
+        self._supports_async = False
+        self._supports_check_mode = False
+        self._result = None
+
+    def _check_argspec(self):
+        aav = AnsibleArgSpecValidator(
+            data=self._task.args,
+            schema=dict(argument_spec=argument_spec),
+            schema_format="argspec",
+            schema_conditionals=dict(
+                required_if=required_if,
+                required_one_of=required_one_of,
+                mutually_exclusive=mutually_exclusive,
+                required_together=required_together,
+            ),
+            name=self._task.action,
+        )
+        valid, errors, self._task.args = aav.validate()
+        if not valid:
+            raise AnsibleActionFail(errors)
+
+    def get_object(self, params):
+        return dict(
+            hostname=params.get("hostname"),
+        )
+
+    def run(self, tmp=None, task_vars=None):
+        self._task.diff = False
+        self._result = super(ActionModule, self).run(tmp, task_vars)
+        self._result["changed"] = False
+        self._check_argspec()
+
+        ise = ISESDK(params=self._task.args)
+
+        response = ise.exec(
+            family="node_deployment",
+            function="sync_node",
+            params=self.get_object(self._task.args),
+        ).response
+
+        self._result.update(dict(ise_response=response))
+        self._result["changed"] = True
+        self._result.update(ise.exit_json())
+        return self._result

--- a/plugins/action/node_group.py
+++ b/plugins/action/node_group.py
@@ -19,22 +19,28 @@ from ansible_collections.cisco.ise.plugins.plugin_utils.ise import (
     ISESDK,
     ise_argument_spec,
     ise_compare_equality,
+    get_dict_result,
 )
 from ansible_collections.cisco.ise.plugins.plugin_utils.exceptions import (
     InconsistentParameters,
 )
 
 argument_spec = ise_argument_spec()
-argument_spec.update(dict(
-    state=dict(type="str", default="present", choices=["present", "absent"]),
-    nodeGroupName=dict(type="str"),
-    name=dict(type="str"),
-    description=dict(type="str"),
-    marCache=dict(type="dict"),
-    forceDelete=dict(type="bool", default=False),
-))
+argument_spec.update(
+    dict(
+        state=dict(type="str", default="present", choices=["present", "absent"]),
+        description=dict(type="str"),
+        marCache=dict(type="dict"),
+        name=dict(type="str"),
+        nodeGroupName=dict(type="str"),
+        forceDelete=dict(type="bool"),
+    )
+)
 
-required_if = []
+required_if = [
+    ("state", "present", ["name", "nodeGroupName"], True),
+    ("state", "absent", ["name", "nodeGroupName"], True),
+]
 required_one_of = []
 mutually_exclusive = []
 required_together = []
@@ -44,44 +50,78 @@ class NodeGroup(object):
     def __init__(self, params, ise):
         self.ise = ise
         self.new_object = dict(
-            node_group_name=params.get("nodeGroupName") or params.get("name"),
-            name=params.get("name"),
             description=params.get("description"),
             mar_cache=params.get("marCache"),
-            force_delete=params.get("forceDelete", False),
+            name=params.get("name"),
+            node_group_name=params.get("nodeGroupName") or params.get("name"),
+            force_delete=params.get("forceDelete"),
         )
 
     def get_object_by_name(self, name):
         try:
-            return self.ise.exec(
+            result = self.ise.exec(
                 family="node_group",
                 function="get_node_group",
                 handle_func_exception=False,
                 params={"node_group_name": name},
-            ).response
+            ).response["response"]
+            result = get_dict_result(result, "name", name)
+        except (TypeError, AttributeError) as e:
+            self.ise.fail_json(
+                msg=(
+                    "An error occured when executing operation."
+                    " Check the configuration of your API Settings and API Gateway settings on your ISE server."
+                    " This collection assumes that the API Gateway, the ERS APIs and OpenAPIs are enabled."
+                    " You may want to enable the (ise_debug: True) argument."
+                    " The error was: {error}"
+                ).format(error=e)
+            )
         except Exception:
-            return None
+            result = None
+        return result
+
+    def get_object_by_id(self, id):
+        # NOTICE: Does not have a get by id method or it is in another action
+        result = None
+        return result
 
     def exists(self):
-        group_name = self.new_object.get("node_group_name")
         prev_obj = None
-        if group_name:
-            prev_obj = self.get_object_by_name(group_name)
+        id_exists = False
+        name_exists = False
+        o_id = self.new_object.get("id")
+        name = self.new_object.get("node_group_name")
+        if o_id:
+            prev_obj = self.get_object_by_id(o_id)
+            id_exists = prev_obj is not None and isinstance(prev_obj, dict)
+        if not id_exists and name:
+            prev_obj = self.get_object_by_name(name)
+            name_exists = prev_obj is not None and isinstance(prev_obj, dict)
+        if name_exists:
+            _id = prev_obj.get("id")
+            if id_exists and name_exists and o_id != _id:
+                raise InconsistentParameters(
+                    "The 'id' and 'name' params don't refer to the same object"
+                )
         it_exists = prev_obj is not None and isinstance(prev_obj, dict)
         return (it_exists, prev_obj)
 
     def requires_update(self, current_obj):
+        requested_obj = self.new_object
+
         obj_params = [
             ("description", "description"),
             ("marCache", "mar_cache"),
         ]
         return any(
-            not ise_compare_equality(current_obj.get(ise_param), self.new_object.get(ansible_param))
+            not ise_compare_equality(
+                current_obj.get(ise_param), requested_obj.get(ansible_param)
+            )
             for (ise_param, ansible_param) in obj_params
         )
 
     def create(self):
-        return self.ise.exec(
+        result = self.ise.exec(
             family="node_group",
             function="create_node_group",
             params=dict(
@@ -90,9 +130,10 @@ class NodeGroup(object):
                 mar_cache=self.new_object.get("mar_cache"),
             ),
         ).response
+        return result
 
     def update(self):
-        return self.ise.exec(
+        result = self.ise.exec(
             family="node_group",
             function="update_node_group",
             params=dict(
@@ -102,16 +143,18 @@ class NodeGroup(object):
                 mar_cache=self.new_object.get("mar_cache"),
             ),
         ).response
+        return result
 
     def delete(self):
-        return self.ise.exec(
+        result = self.ise.exec(
             family="node_group",
             function="delete_node_group",
             params=dict(
-                force_delete=self.new_object.get("force_delete", False),
+                force_delete=self.new_object.get("force_delete"),
                 node_group_name=self.new_object.get("node_group_name"),
             ),
         ).response
+        return result
 
 
 class ActionModule(ActionBase):
@@ -150,7 +193,9 @@ class ActionModule(ActionBase):
 
         ise = ISESDK(params=self._task.args)
         obj = NodeGroup(self._task.args, ise)
+
         state = self._task.args.get("state")
+
         response = None
 
         if state == "present":
@@ -159,18 +204,19 @@ class ActionModule(ActionBase):
                 if obj.requires_update(prev_obj):
                     ise_update_response = obj.update()
                     self._result.update(dict(ise_update_response=ise_update_response))
-                    (_, updated_obj) = obj.exists()
-                    ise.object_updated()
+                    (obj_exists, updated_obj) = obj.exists()
                     response = updated_obj
+                    ise.object_updated()
                 else:
                     response = prev_obj
                     ise.object_already_present()
             else:
                 ise_create_response = obj.create()
                 self._result.update(dict(ise_create_response=ise_create_response))
-                (_, created_obj) = obj.exists()
+                (obj_exists, created_obj) = obj.exists()
                 response = created_obj
                 ise.object_created()
+
         elif state == "absent":
             (obj_exists, prev_obj) = obj.exists()
             if obj_exists:
@@ -178,7 +224,6 @@ class ActionModule(ActionBase):
                 response = prev_obj
                 ise.object_deleted()
             else:
-                response = None
                 ise.object_already_absent()
 
         self._result.update(dict(ise_response=response))

--- a/plugins/action/node_group.py
+++ b/plugins/action/node_group.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+from ansible.plugins.action import ActionBase
+try:
+    from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
+        AnsibleArgSpecValidator,
+    )
+except ImportError:
+    ANSIBLE_UTILS_IS_INSTALLED = False
+else:
+    ANSIBLE_UTILS_IS_INSTALLED = True
+from ansible.errors import AnsibleActionFail
+from ansible_collections.cisco.ise.plugins.plugin_utils.ise import (
+    ISESDK,
+    ise_argument_spec,
+    ise_compare_equality,
+)
+from ansible_collections.cisco.ise.plugins.plugin_utils.exceptions import (
+    InconsistentParameters,
+)
+
+argument_spec = ise_argument_spec()
+argument_spec.update(dict(
+    state=dict(type="str", default="present", choices=["present", "absent"]),
+    nodeGroupName=dict(type="str"),
+    name=dict(type="str"),
+    description=dict(type="str"),
+    marCache=dict(type="dict"),
+    forceDelete=dict(type="bool", default=False),
+))
+
+required_if = []
+required_one_of = []
+mutually_exclusive = []
+required_together = []
+
+
+class NodeGroup(object):
+    def __init__(self, params, ise):
+        self.ise = ise
+        self.new_object = dict(
+            node_group_name=params.get("nodeGroupName") or params.get("name"),
+            name=params.get("name"),
+            description=params.get("description"),
+            mar_cache=params.get("marCache"),
+            force_delete=params.get("forceDelete", False),
+        )
+
+    def get_object_by_name(self, name):
+        try:
+            return self.ise.exec(
+                family="node_group",
+                function="get_node_group",
+                handle_func_exception=False,
+                params={"node_group_name": name},
+            ).response
+        except Exception:
+            return None
+
+    def exists(self):
+        group_name = self.new_object.get("node_group_name")
+        prev_obj = None
+        if group_name:
+            prev_obj = self.get_object_by_name(group_name)
+        it_exists = prev_obj is not None and isinstance(prev_obj, dict)
+        return (it_exists, prev_obj)
+
+    def requires_update(self, current_obj):
+        obj_params = [
+            ("description", "description"),
+            ("marCache", "mar_cache"),
+        ]
+        return any(
+            not ise_compare_equality(current_obj.get(ise_param), self.new_object.get(ansible_param))
+            for (ise_param, ansible_param) in obj_params
+        )
+
+    def create(self):
+        return self.ise.exec(
+            family="node_group",
+            function="create_node_group",
+            params=dict(
+                name=self.new_object.get("name"),
+                description=self.new_object.get("description"),
+                mar_cache=self.new_object.get("mar_cache"),
+            ),
+        ).response
+
+    def update(self):
+        return self.ise.exec(
+            family="node_group",
+            function="update_node_group",
+            params=dict(
+                node_group_name=self.new_object.get("node_group_name"),
+                name=self.new_object.get("name"),
+                description=self.new_object.get("description"),
+                mar_cache=self.new_object.get("mar_cache"),
+            ),
+        ).response
+
+    def delete(self):
+        return self.ise.exec(
+            family="node_group",
+            function="delete_node_group",
+            params=dict(
+                force_delete=self.new_object.get("force_delete", False),
+                node_group_name=self.new_object.get("node_group_name"),
+            ),
+        ).response
+
+
+class ActionModule(ActionBase):
+    def __init__(self, *args, **kwargs):
+        if not ANSIBLE_UTILS_IS_INSTALLED:
+            raise AnsibleActionFail(
+                "ansible.utils is not installed. Execute 'ansible-galaxy collection install ansible.utils'"
+            )
+        super(ActionModule, self).__init__(*args, **kwargs)
+        self._supports_async = False
+        self._supports_check_mode = False
+        self._result = None
+
+    def _check_argspec(self):
+        aav = AnsibleArgSpecValidator(
+            data=self._task.args,
+            schema=dict(argument_spec=argument_spec),
+            schema_format="argspec",
+            schema_conditionals=dict(
+                required_if=required_if,
+                required_one_of=required_one_of,
+                mutually_exclusive=mutually_exclusive,
+                required_together=required_together,
+            ),
+            name=self._task.action,
+        )
+        valid, errors, self._task.args = aav.validate()
+        if not valid:
+            raise AnsibleActionFail(errors)
+
+    def run(self, tmp=None, task_vars=None):
+        self._task.diff = False
+        self._result = super(ActionModule, self).run(tmp, task_vars)
+        self._result["changed"] = False
+        self._check_argspec()
+
+        ise = ISESDK(params=self._task.args)
+        obj = NodeGroup(self._task.args, ise)
+        state = self._task.args.get("state")
+        response = None
+
+        if state == "present":
+            (obj_exists, prev_obj) = obj.exists()
+            if obj_exists:
+                if obj.requires_update(prev_obj):
+                    ise_update_response = obj.update()
+                    self._result.update(dict(ise_update_response=ise_update_response))
+                    (_, updated_obj) = obj.exists()
+                    ise.object_updated()
+                    response = updated_obj
+                else:
+                    response = prev_obj
+                    ise.object_already_present()
+            else:
+                ise_create_response = obj.create()
+                self._result.update(dict(ise_create_response=ise_create_response))
+                (_, created_obj) = obj.exists()
+                response = created_obj
+                ise.object_created()
+        elif state == "absent":
+            (obj_exists, prev_obj) = obj.exists()
+            if obj_exists:
+                obj.delete()
+                response = prev_obj
+                ise.object_deleted()
+            else:
+                response = None
+                ise.object_already_absent()
+
+        self._result.update(dict(ise_response=response))
+        self._result.update(ise.exit_json())
+        return self._result

--- a/plugins/action/node_group_info.py
+++ b/plugins/action/node_group_info.py
@@ -78,13 +78,13 @@ class ActionModule(ActionBase):
                 family="node_group",
                 function="get_node_group",
                 params=self.get_object(self._task.args),
-            ).response
+            ).response["response"]
         else:
             response = ise.exec(
                 family="node_group",
                 function="get_node_groups",
                 params={},
-            ).response
+            ).response["response"]
 
         self._result.update(dict(ise_response=response))
         self._result.update(ise.exit_json())

--- a/plugins/action/node_group_info.py
+++ b/plugins/action/node_group_info.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+from ansible.plugins.action import ActionBase
+try:
+    from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
+        AnsibleArgSpecValidator,
+    )
+except ImportError:
+    ANSIBLE_UTILS_IS_INSTALLED = False
+else:
+    ANSIBLE_UTILS_IS_INSTALLED = True
+from ansible.errors import AnsibleActionFail
+from ansible_collections.cisco.ise.plugins.plugin_utils.ise import (
+    ISESDK,
+    ise_argument_spec,
+)
+
+argument_spec = ise_argument_spec()
+argument_spec.update(dict(
+    nodeGroupName=dict(type="str"),
+))
+
+required_if = []
+required_one_of = []
+mutually_exclusive = []
+required_together = []
+
+
+class ActionModule(ActionBase):
+    def __init__(self, *args, **kwargs):
+        if not ANSIBLE_UTILS_IS_INSTALLED:
+            raise AnsibleActionFail(
+                "ansible.utils is not installed. Execute 'ansible-galaxy collection install ansible.utils'"
+            )
+        super(ActionModule, self).__init__(*args, **kwargs)
+        self._supports_async = False
+        self._supports_check_mode = True
+        self._result = None
+
+    def _check_argspec(self):
+        aav = AnsibleArgSpecValidator(
+            data=self._task.args,
+            schema=dict(argument_spec=argument_spec),
+            schema_format="argspec",
+            schema_conditionals=dict(
+                required_if=required_if,
+                required_one_of=required_one_of,
+                mutually_exclusive=mutually_exclusive,
+                required_together=required_together,
+            ),
+            name=self._task.action,
+        )
+        valid, errors, self._task.args = aav.validate()
+        if not valid:
+            raise AnsibleActionFail(errors)
+
+    def get_object(self, params):
+        return dict(
+            node_group_name=params.get("nodeGroupName"),
+        )
+
+    def run(self, tmp=None, task_vars=None):
+        self._task.diff = False
+        self._result = super(ActionModule, self).run(tmp, task_vars)
+        self._result["changed"] = False
+        self._check_argspec()
+
+        ise = ISESDK(params=self._task.args)
+        node_group_name = self._task.args.get("nodeGroupName")
+
+        if node_group_name:
+            response = ise.exec(
+                family="node_group",
+                function="get_node_group",
+                params=self.get_object(self._task.args),
+            ).response
+        else:
+            response = ise.exec(
+                family="node_group",
+                function="get_node_groups",
+                params={},
+            ).response
+
+        self._result.update(dict(ise_response=response))
+        self._result.update(ise.exit_json())
+        return self._result

--- a/plugins/action/node_group_node_create.py
+++ b/plugins/action/node_group_node_create.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+from ansible.plugins.action import ActionBase
+try:
+    from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
+        AnsibleArgSpecValidator,
+    )
+except ImportError:
+    ANSIBLE_UTILS_IS_INSTALLED = False
+else:
+    ANSIBLE_UTILS_IS_INSTALLED = True
+from ansible.errors import AnsibleActionFail
+from ansible_collections.cisco.ise.plugins.plugin_utils.ise import (
+    ISESDK,
+    ise_argument_spec,
+)
+
+argument_spec = ise_argument_spec()
+argument_spec.update(dict(
+    nodeGroupName=dict(type="str"),
+    hostname=dict(type="str"),
+))
+
+required_if = []
+required_one_of = []
+mutually_exclusive = []
+required_together = []
+
+
+class ActionModule(ActionBase):
+    def __init__(self, *args, **kwargs):
+        if not ANSIBLE_UTILS_IS_INSTALLED:
+            raise AnsibleActionFail(
+                "ansible.utils is not installed. Execute 'ansible-galaxy collection install ansible.utils'"
+            )
+        super(ActionModule, self).__init__(*args, **kwargs)
+        self._supports_async = False
+        self._supports_check_mode = False
+        self._result = None
+
+    def _check_argspec(self):
+        aav = AnsibleArgSpecValidator(
+            data=self._task.args,
+            schema=dict(argument_spec=argument_spec),
+            schema_format="argspec",
+            schema_conditionals=dict(
+                required_if=required_if,
+                required_one_of=required_one_of,
+                mutually_exclusive=mutually_exclusive,
+                required_together=required_together,
+            ),
+            name=self._task.action,
+        )
+        valid, errors, self._task.args = aav.validate()
+        if not valid:
+            raise AnsibleActionFail(errors)
+
+    def run(self, tmp=None, task_vars=None):
+        self._task.diff = False
+        self._result = super(ActionModule, self).run(tmp, task_vars)
+        self._result["changed"] = False
+        self._check_argspec()
+
+        ise = ISESDK(params=self._task.args)
+
+        response = ise.exec(
+            family="node_group",
+            function="add_node",
+            params=dict(
+                node_group_name=self._task.args.get("nodeGroupName"),
+                hostname=self._task.args.get("hostname"),
+            ),
+        ).response
+
+        self._result.update(dict(ise_response=response))
+        self._result["changed"] = True
+        self._result.update(ise.exit_json())
+        return self._result

--- a/plugins/action/node_group_node_delete.py
+++ b/plugins/action/node_group_node_delete.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+from ansible.plugins.action import ActionBase
+try:
+    from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
+        AnsibleArgSpecValidator,
+    )
+except ImportError:
+    ANSIBLE_UTILS_IS_INSTALLED = False
+else:
+    ANSIBLE_UTILS_IS_INSTALLED = True
+from ansible.errors import AnsibleActionFail
+from ansible_collections.cisco.ise.plugins.plugin_utils.ise import (
+    ISESDK,
+    ise_argument_spec,
+)
+
+argument_spec = ise_argument_spec()
+argument_spec.update(dict(
+    nodeGroupName=dict(type="str"),
+    hostname=dict(type="str"),
+))
+
+required_if = []
+required_one_of = []
+mutually_exclusive = []
+required_together = []
+
+
+class ActionModule(ActionBase):
+    def __init__(self, *args, **kwargs):
+        if not ANSIBLE_UTILS_IS_INSTALLED:
+            raise AnsibleActionFail(
+                "ansible.utils is not installed. Execute 'ansible-galaxy collection install ansible.utils'"
+            )
+        super(ActionModule, self).__init__(*args, **kwargs)
+        self._supports_async = False
+        self._supports_check_mode = False
+        self._result = None
+
+    def _check_argspec(self):
+        aav = AnsibleArgSpecValidator(
+            data=self._task.args,
+            schema=dict(argument_spec=argument_spec),
+            schema_format="argspec",
+            schema_conditionals=dict(
+                required_if=required_if,
+                required_one_of=required_one_of,
+                mutually_exclusive=mutually_exclusive,
+                required_together=required_together,
+            ),
+            name=self._task.action,
+        )
+        valid, errors, self._task.args = aav.validate()
+        if not valid:
+            raise AnsibleActionFail(errors)
+
+    def run(self, tmp=None, task_vars=None):
+        self._task.diff = False
+        self._result = super(ActionModule, self).run(tmp, task_vars)
+        self._result["changed"] = False
+        self._check_argspec()
+
+        ise = ISESDK(params=self._task.args)
+
+        response = ise.exec(
+            family="node_group",
+            function="remove_node",
+            params=dict(
+                node_group_name=self._task.args.get("nodeGroupName"),
+                hostname=self._task.args.get("hostname"),
+            ),
+        ).response
+
+        self._result.update(dict(ise_response=response))
+        self._result["changed"] = True
+        self._result.update(ise.exit_json())
+        return self._result

--- a/plugins/action/node_group_node_info.py
+++ b/plugins/action/node_group_node_info.py
@@ -76,7 +76,7 @@ class ActionModule(ActionBase):
             family="node_group",
             function="get_nodes",
             params=self.get_object(self._task.args),
-        ).response
+        ).response["response"]
 
         self._result.update(dict(ise_response=response))
         self._result.update(ise.exit_json())

--- a/plugins/action/node_group_node_info.py
+++ b/plugins/action/node_group_node_info.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+from ansible.plugins.action import ActionBase
+try:
+    from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
+        AnsibleArgSpecValidator,
+    )
+except ImportError:
+    ANSIBLE_UTILS_IS_INSTALLED = False
+else:
+    ANSIBLE_UTILS_IS_INSTALLED = True
+from ansible.errors import AnsibleActionFail
+from ansible_collections.cisco.ise.plugins.plugin_utils.ise import (
+    ISESDK,
+    ise_argument_spec,
+)
+
+argument_spec = ise_argument_spec()
+argument_spec.update(dict(
+    nodeGroupName=dict(type="str"),
+))
+
+required_if = []
+required_one_of = []
+mutually_exclusive = []
+required_together = []
+
+
+class ActionModule(ActionBase):
+    def __init__(self, *args, **kwargs):
+        if not ANSIBLE_UTILS_IS_INSTALLED:
+            raise AnsibleActionFail(
+                "ansible.utils is not installed. Execute 'ansible-galaxy collection install ansible.utils'"
+            )
+        super(ActionModule, self).__init__(*args, **kwargs)
+        self._supports_async = False
+        self._supports_check_mode = True
+        self._result = None
+
+    def _check_argspec(self):
+        aav = AnsibleArgSpecValidator(
+            data=self._task.args,
+            schema=dict(argument_spec=argument_spec),
+            schema_format="argspec",
+            schema_conditionals=dict(
+                required_if=required_if,
+                required_one_of=required_one_of,
+                mutually_exclusive=mutually_exclusive,
+                required_together=required_together,
+            ),
+            name=self._task.action,
+        )
+        valid, errors, self._task.args = aav.validate()
+        if not valid:
+            raise AnsibleActionFail(errors)
+
+    def get_object(self, params):
+        return dict(
+            node_group_name=params.get("nodeGroupName"),
+        )
+
+    def run(self, tmp=None, task_vars=None):
+        self._task.diff = False
+        self._result = super(ActionModule, self).run(tmp, task_vars)
+        self._result["changed"] = False
+        self._check_argspec()
+
+        ise = ISESDK(params=self._task.args)
+
+        response = ise.exec(
+            family="node_group",
+            function="get_nodes",
+            params=self.get_object(self._task.args),
+        ).response
+
+        self._result.update(dict(ise_response=response))
+        self._result.update(ise.exit_json())
+        return self._result

--- a/plugins/action/node_secondary_to_primary.py
+++ b/plugins/action/node_secondary_to_primary.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+from ansible.plugins.action import ActionBase
+try:
+    from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
+        AnsibleArgSpecValidator,
+    )
+except ImportError:
+    ANSIBLE_UTILS_IS_INSTALLED = False
+else:
+    ANSIBLE_UTILS_IS_INSTALLED = True
+from ansible.errors import AnsibleActionFail
+from ansible_collections.cisco.ise.plugins.plugin_utils.ise import (
+    ISESDK,
+    ise_argument_spec,
+)
+
+argument_spec = ise_argument_spec()
+
+required_if = []
+required_one_of = []
+mutually_exclusive = []
+required_together = []
+
+
+class ActionModule(ActionBase):
+    def __init__(self, *args, **kwargs):
+        if not ANSIBLE_UTILS_IS_INSTALLED:
+            raise AnsibleActionFail(
+                "ansible.utils is not installed. Execute 'ansible-galaxy collection install ansible.utils'"
+            )
+        super(ActionModule, self).__init__(*args, **kwargs)
+        self._supports_async = False
+        self._supports_check_mode = False
+        self._result = None
+
+    def _check_argspec(self):
+        aav = AnsibleArgSpecValidator(
+            data=self._task.args,
+            schema=dict(argument_spec=argument_spec),
+            schema_format="argspec",
+            schema_conditionals=dict(
+                required_if=required_if,
+                required_one_of=required_one_of,
+                mutually_exclusive=mutually_exclusive,
+                required_together=required_together,
+            ),
+            name=self._task.action,
+        )
+        valid, errors, self._task.args = aav.validate()
+        if not valid:
+            raise AnsibleActionFail(errors)
+
+    def run(self, tmp=None, task_vars=None):
+        self._task.diff = False
+        self._result = super(ActionModule, self).run(tmp, task_vars)
+        self._result["changed"] = False
+        self._check_argspec()
+
+        ise = ISESDK(params=self._task.args)
+
+        response = ise.exec(
+            family="node_deployment",
+            function="promote_node",
+            params={},
+        ).response
+
+        self._result.update(dict(ise_response=response))
+        self._result["changed"] = True
+        self._result.update(ise.exit_json())
+        return self._result

--- a/plugins/action/node_secondary_to_primary.py
+++ b/plugins/action/node_secondary_to_primary.py
@@ -18,14 +18,85 @@ from ansible.errors import AnsibleActionFail
 from ansible_collections.cisco.ise.plugins.plugin_utils.ise import (
     ISESDK,
     ise_argument_spec,
+    get_dict_result,
+)
+from ansible_collections.cisco.ise.plugins.plugin_utils.exceptions import (
+    InconsistentParameters,
 )
 
 argument_spec = ise_argument_spec()
+argument_spec.update(
+    dict(
+        hostname=dict(type="str"),
+    )
+)
 
 required_if = []
 required_one_of = []
 mutually_exclusive = []
 required_together = []
+
+
+class NodeSecondaryToPrimary(object):
+    def __init__(self, params, ise):
+        self.ise = ise
+        self.new_object = dict(
+            hostname=params.get("hostname"),
+        )
+
+    def get_object_by_name(self, name):
+        try:
+            result = self.ise.exec(
+                family="node_deployment",
+                function="get_node_details",
+                params={"hostname": name},
+                handle_func_exception=False,
+            ).response["response"]
+            result = get_dict_result(result, "name", name)
+        except (TypeError, AttributeError) as e:
+            self.ise.fail_json(
+                msg=(
+                    "An error occured when executing operation."
+                    " Check the configuration of your API Settings and API Gateway settings on your ISE server."
+                    " This collection assumes that the API Gateway, the ERS APIs and OpenAPIs are enabled."
+                    " You may want to enable the (ise_debug: True) argument."
+                    " The error was: {error}"
+                ).format(error=e)
+            )
+        except Exception:
+            result = None
+        return result
+
+    def get_object_by_id(self, id):
+        # NOTICE: Does not have a get by id method or it is in another action
+        result = None
+        return result
+
+    def exists(self):
+        prev_obj = None
+        id_exists = False
+        name_exists = False
+        o_id = self.new_object.get("id")
+        name = self.new_object.get("hostname")
+        if o_id:
+            prev_obj = self.get_object_by_id(o_id)
+            id_exists = prev_obj is not None and isinstance(prev_obj, dict)
+        if not id_exists and name:
+            prev_obj = self.get_object_by_name(name)
+            name_exists = prev_obj is not None and isinstance(prev_obj, dict)
+        if name_exists:
+            _id = prev_obj.get("id")
+            if id_exists and name_exists and o_id != _id:
+                raise InconsistentParameters(
+                    "The 'id' and 'name' params don't refer to the same object"
+                )
+        it_exists = prev_obj is not None and isinstance(prev_obj, dict)
+        return (it_exists, prev_obj)
+
+    def requires_update(self, current_obj):
+        if "SecondaryAdmin" in current_obj.roles:
+            return True
+        return False
 
 
 class ActionModule(ActionBase):
@@ -56,6 +127,10 @@ class ActionModule(ActionBase):
         if not valid:
             raise AnsibleActionFail(errors)
 
+    def get_object(self, params):
+        new_object = dict()
+        return new_object
+
     def run(self, tmp=None, task_vars=None):
         self._task.diff = False
         self._result = super(ActionModule, self).run(tmp, task_vars)
@@ -63,14 +138,30 @@ class ActionModule(ActionBase):
         self._check_argspec()
 
         ise = ISESDK(params=self._task.args)
+        obj = NodeSecondaryToPrimary(self._task.args, ise)
 
-        response = ise.exec(
-            family="node_deployment",
-            function="promote_node",
-            params={},
-        ).response
+        name = self._task.args.get("hostname")
+
+        response = None
+        (obj_exists, prev_obj) = obj.exists()
+        if obj_exists:
+            if obj.requires_update(prev_obj):
+                response = ise.exec(
+                    family="node_deployment",
+                    function="promote_node",
+                    params=self.get_object(self._task.args),
+                ).response
+                ise.object_updated()
+            else:
+                if "PrimaryAdmin" in prev_obj.roles:
+                    ise.result["result"] = "Node is already Primary"
+                else:
+                    ise.fail_json("Invoke this API on Secondary PAN node only")
+        else:
+            ise.fail_json(
+                "No such HostConfig with hostName [{hostname}]".format(hostname=name)
+            )
 
         self._result.update(dict(ise_response=response))
-        self._result["changed"] = True
         self._result.update(ise.exit_json())
         return self._result

--- a/plugins/action/node_services_profiler_probe_config.py
+++ b/plugins/action/node_services_profiler_probe_config.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+from ansible.plugins.action import ActionBase
+try:
+    from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
+        AnsibleArgSpecValidator,
+    )
+except ImportError:
+    ANSIBLE_UTILS_IS_INSTALLED = False
+else:
+    ANSIBLE_UTILS_IS_INSTALLED = True
+from ansible.errors import AnsibleActionFail
+from ansible_collections.cisco.ise.plugins.plugin_utils.ise import (
+    ISESDK,
+    ise_argument_spec,
+)
+
+argument_spec = ise_argument_spec()
+argument_spec.update(dict(
+    state=dict(type="str", default="present", choices=["present"]),
+    hostname=dict(type="str"),
+    activeDirectory=dict(type="dict"),
+    dhcp=dict(type="dict"),
+    dhcpSpan=dict(type="dict"),
+    dns=dict(type="dict"),
+    http=dict(type="dict"),
+    netflow=dict(type="dict"),
+    nmap=dict(type="list"),
+    pxgrid=dict(type="bool"),
+    radius=dict(type="dict"),
+    snmpQuery=dict(type="dict"),
+    snmpTrap=dict(type="dict"),
+))
+
+required_if = []
+required_one_of = []
+mutually_exclusive = []
+required_together = []
+
+
+class ActionModule(ActionBase):
+    def __init__(self, *args, **kwargs):
+        if not ANSIBLE_UTILS_IS_INSTALLED:
+            raise AnsibleActionFail(
+                "ansible.utils is not installed. Execute 'ansible-galaxy collection install ansible.utils'"
+            )
+        super(ActionModule, self).__init__(*args, **kwargs)
+        self._supports_async = False
+        self._supports_check_mode = False
+        self._result = None
+
+    def _check_argspec(self):
+        aav = AnsibleArgSpecValidator(
+            data=self._task.args,
+            schema=dict(argument_spec=argument_spec),
+            schema_format="argspec",
+            schema_conditionals=dict(
+                required_if=required_if,
+                required_one_of=required_one_of,
+                mutually_exclusive=mutually_exclusive,
+                required_together=required_together,
+            ),
+            name=self._task.action,
+        )
+        valid, errors, self._task.args = aav.validate()
+        if not valid:
+            raise AnsibleActionFail(errors)
+
+    def run(self, tmp=None, task_vars=None):
+        self._task.diff = False
+        self._result = super(ActionModule, self).run(tmp, task_vars)
+        self._result["changed"] = False
+        self._check_argspec()
+
+        ise = ISESDK(params=self._task.args)
+        params = self._task.args
+
+        response = ise.exec(
+            family="node_services",
+            function="set_profiler_probe_config",
+            params=dict(
+                hostname=params.get("hostname"),
+                active_directory=params.get("activeDirectory"),
+                dhcp=params.get("dhcp"),
+                dhcp_span=params.get("dhcpSpan"),
+                dns=params.get("dns"),
+                http=params.get("http"),
+                netflow=params.get("netflow"),
+                nmap=params.get("nmap"),
+                pxgrid=params.get("pxgrid"),
+                radius=params.get("radius"),
+                snmp_query=params.get("snmpQuery"),
+                snmp_trap=params.get("snmpTrap"),
+            ),
+        ).response
+
+        self._result.update(dict(ise_response=response))
+        self._result["changed"] = True
+        self._result.update(ise.exit_json())
+        return self._result

--- a/plugins/action/node_services_profiler_probe_config.py
+++ b/plugins/action/node_services_profiler_probe_config.py
@@ -18,29 +18,146 @@ from ansible.errors import AnsibleActionFail
 from ansible_collections.cisco.ise.plugins.plugin_utils.ise import (
     ISESDK,
     ise_argument_spec,
+    ise_compare_equality2,
+    get_dict_result,
+)
+from ansible_collections.cisco.ise.plugins.plugin_utils.exceptions import (
+    InconsistentParameters,
 )
 
 argument_spec = ise_argument_spec()
-argument_spec.update(dict(
-    state=dict(type="str", default="present", choices=["present"]),
-    hostname=dict(type="str"),
-    activeDirectory=dict(type="dict"),
-    dhcp=dict(type="dict"),
-    dhcpSpan=dict(type="dict"),
-    dns=dict(type="dict"),
-    http=dict(type="dict"),
-    netflow=dict(type="dict"),
-    nmap=dict(type="list"),
-    pxgrid=dict(type="bool"),
-    radius=dict(type="dict"),
-    snmpQuery=dict(type="dict"),
-    snmpTrap=dict(type="dict"),
-))
+argument_spec.update(
+    dict(
+        state=dict(type="str", default="present", choices=["present"]),
+        activeDirectory=dict(type="dict"),
+        dhcp=dict(type="dict"),
+        dhcpSpan=dict(type="dict"),
+        dns=dict(type="dict"),
+        http=dict(type="dict"),
+        netflow=dict(type="dict"),
+        nmap=dict(type="list"),
+        pxgrid=dict(type="list"),
+        radius=dict(type="list"),
+        snmpQuery=dict(type="dict"),
+        snmpTrap=dict(type="dict"),
+        hostname=dict(type="str"),
+    )
+)
 
-required_if = []
+required_if = [
+    ("state", "present", ["hostname"], True),
+]
 required_one_of = []
 mutually_exclusive = []
 required_together = []
+
+
+class NodeServicesProfilerProbeConfig(object):
+    def __init__(self, params, ise):
+        self.ise = ise
+        self.new_object = dict(
+            active_directory=params.get("activeDirectory"),
+            dhcp=params.get("dhcp"),
+            dhcp_span=params.get("dhcpSpan"),
+            dns=params.get("dns"),
+            http=params.get("http"),
+            netflow=params.get("netflow"),
+            nmap=params.get("nmap"),
+            pxgrid=params.get("pxgrid"),
+            radius=params.get("radius"),
+            snmp_query=params.get("snmpQuery"),
+            snmp_trap=params.get("snmpTrap"),
+            hostname=params.get("hostname"),
+        )
+
+    def get_object_by_name(self, name):
+        try:
+            result = self.ise.exec(
+                family="node_services",
+                function="get_profiler_probe_config",
+                params={"hostname": name},
+                handle_func_exception=False,
+            ).response["response"]
+            result = get_dict_result(result, "name", name)
+        except (TypeError, AttributeError) as e:
+            self.ise.fail_json(
+                msg=(
+                    "An error occured when executing operation."
+                    " Check the configuration of your API Settings and API Gateway settings on your ISE server."
+                    " This collection assumes that the API Gateway, the ERS APIs and OpenAPIs are enabled."
+                    " You may want to enable the (ise_debug: True) argument."
+                    " The error was: {error}"
+                ).format(error=e)
+            )
+        except Exception:
+            result = None
+        return result
+
+    def get_object_by_id(self, id):
+        # NOTICE: Does not have a get by id method or it is in another action
+        result = None
+        return result
+
+    def exists(self):
+        prev_obj = None
+        id_exists = False
+        name_exists = False
+        o_id = self.new_object.get("id")
+        name = self.new_object.get("hostname")
+        if o_id:
+            prev_obj = self.get_object_by_id(o_id)
+            id_exists = prev_obj is not None and isinstance(prev_obj, dict)
+        if not id_exists and name:
+            prev_obj = self.get_object_by_name(name)
+            name_exists = prev_obj is not None and isinstance(prev_obj, dict)
+        if name_exists:
+            _id = prev_obj.get("id")
+            if id_exists and name_exists and o_id != _id:
+                raise InconsistentParameters(
+                    "The 'id' and 'name' params don't refer to the same object"
+                )
+        it_exists = prev_obj is not None and isinstance(prev_obj, dict)
+        return (it_exists, prev_obj)
+
+    def requires_update(self, current_obj):
+        requested_obj = self.new_object
+
+        obj_params = [
+            ("activeDirectory", "active_directory", False),
+            ("dhcp", "dhcp", False),
+            ("dhcpSpan", "dhcp_span", False),
+            ("dns", "dns", False),
+            ("http", "http", False),
+            ("netflow", "netflow", False),
+            ("nmap", "nmap", False),
+            ("pxgrid", "pxgrid", False),
+            ("radius", "radius", False),
+            ("snmpQuery", "snmp_query", False),
+            ("snmpTrap", "snmp_trap", False),
+            ("hostname", "hostname", True),
+        ]
+        return any(
+            not ise_compare_equality2(
+                current_obj.get(ise_param),
+                requested_obj.get(ansible_param),
+                is_query_param,
+            )
+            for (ise_param, ansible_param, is_query_param) in obj_params
+        )
+
+    def update(self):
+        id = self.new_object.get("id")
+        name = self.new_object.get("hostname")
+        result = None
+        if not name:
+            name_ = self.get_object_by_id(id).get("hostname")
+            self.new_object.update(dict(name=name_))
+        result = self.ise.exec(
+            family="node_services",
+            function="set_profiler_probe_config",
+            params=self.new_object,
+        ).response
+        return result
 
 
 class ActionModule(ActionBase):
@@ -78,28 +195,26 @@ class ActionModule(ActionBase):
         self._check_argspec()
 
         ise = ISESDK(params=self._task.args)
-        params = self._task.args
+        obj = NodeServicesProfilerProbeConfig(self._task.args, ise)
 
-        response = ise.exec(
-            family="node_services",
-            function="set_profiler_probe_config",
-            params=dict(
-                hostname=params.get("hostname"),
-                active_directory=params.get("activeDirectory"),
-                dhcp=params.get("dhcp"),
-                dhcp_span=params.get("dhcpSpan"),
-                dns=params.get("dns"),
-                http=params.get("http"),
-                netflow=params.get("netflow"),
-                nmap=params.get("nmap"),
-                pxgrid=params.get("pxgrid"),
-                radius=params.get("radius"),
-                snmp_query=params.get("snmpQuery"),
-                snmp_trap=params.get("snmpTrap"),
-            ),
-        ).response
+        state = self._task.args.get("state")
+
+        response = None
+        if state == "present":
+            (obj_exists, prev_obj) = obj.exists()
+            if obj_exists:
+                if obj.requires_update(prev_obj):
+                    ise_update_response = obj.update()
+                    self._result.update(dict(ise_update_response=ise_update_response))
+                    (obj_exists, updated_obj) = obj.exists()
+                    response = updated_obj
+                    ise.object_updated()
+                else:
+                    response = prev_obj
+                    ise.object_already_present()
+            else:
+                ise.fail_json("Object does not exists, plugin only has update")
 
         self._result.update(dict(ise_response=response))
-        self._result["changed"] = True
         self._result.update(ise.exit_json())
         return self._result

--- a/plugins/action/node_services_profiler_probe_config_info.py
+++ b/plugins/action/node_services_profiler_probe_config_info.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+from ansible.plugins.action import ActionBase
+try:
+    from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
+        AnsibleArgSpecValidator,
+    )
+except ImportError:
+    ANSIBLE_UTILS_IS_INSTALLED = False
+else:
+    ANSIBLE_UTILS_IS_INSTALLED = True
+from ansible.errors import AnsibleActionFail
+from ansible_collections.cisco.ise.plugins.plugin_utils.ise import (
+    ISESDK,
+    ise_argument_spec,
+)
+
+argument_spec = ise_argument_spec()
+argument_spec.update(dict(
+    hostname=dict(type="str"),
+))
+
+required_if = []
+required_one_of = []
+mutually_exclusive = []
+required_together = []
+
+
+class ActionModule(ActionBase):
+    def __init__(self, *args, **kwargs):
+        if not ANSIBLE_UTILS_IS_INSTALLED:
+            raise AnsibleActionFail(
+                "ansible.utils is not installed. Execute 'ansible-galaxy collection install ansible.utils'"
+            )
+        super(ActionModule, self).__init__(*args, **kwargs)
+        self._supports_async = False
+        self._supports_check_mode = True
+        self._result = None
+
+    def _check_argspec(self):
+        aav = AnsibleArgSpecValidator(
+            data=self._task.args,
+            schema=dict(argument_spec=argument_spec),
+            schema_format="argspec",
+            schema_conditionals=dict(
+                required_if=required_if,
+                required_one_of=required_one_of,
+                mutually_exclusive=mutually_exclusive,
+                required_together=required_together,
+            ),
+            name=self._task.action,
+        )
+        valid, errors, self._task.args = aav.validate()
+        if not valid:
+            raise AnsibleActionFail(errors)
+
+    def run(self, tmp=None, task_vars=None):
+        self._task.diff = False
+        self._result = super(ActionModule, self).run(tmp, task_vars)
+        self._result["changed"] = False
+        self._check_argspec()
+
+        ise = ISESDK(params=self._task.args)
+
+        response = ise.exec(
+            family="node_services",
+            function="get_profiler_probe_config",
+            params=dict(
+                hostname=self._task.args.get("hostname"),
+            ),
+        ).response
+
+        self._result.update(dict(ise_response=response))
+        self._result.update(ise.exit_json())
+        return self._result

--- a/plugins/action/node_services_profiler_probe_config_info.py
+++ b/plugins/action/node_services_profiler_probe_config_info.py
@@ -73,7 +73,7 @@ class ActionModule(ActionBase):
             params=dict(
                 hostname=self._task.args.get("hostname"),
             ),
-        ).response
+        ).response["response"]
 
         self._result.update(dict(ise_response=response))
         self._result.update(ise.exit_json())

--- a/plugins/action/node_standalone_to_primary.py
+++ b/plugins/action/node_standalone_to_primary.py
@@ -18,14 +18,85 @@ from ansible.errors import AnsibleActionFail
 from ansible_collections.cisco.ise.plugins.plugin_utils.ise import (
     ISESDK,
     ise_argument_spec,
+    get_dict_result,
+)
+from ansible_collections.cisco.ise.plugins.plugin_utils.exceptions import (
+    InconsistentParameters,
 )
 
 argument_spec = ise_argument_spec()
+argument_spec.update(
+    dict(
+        hostname=dict(type="str"),
+    )
+)
 
 required_if = []
 required_one_of = []
 mutually_exclusive = []
 required_together = []
+
+
+class NodeStandaloneToPrimary(object):
+    def __init__(self, params, ise):
+        self.ise = ise
+        self.new_object = dict(
+            hostname=params.get("hostname"),
+        )
+
+    def get_object_by_name(self, name):
+        try:
+            result = self.ise.exec(
+                family="node_deployment",
+                function="get_node_details",
+                params={"hostname": name},
+                handle_func_exception=False,
+            ).response["response"]
+            result = get_dict_result(result, "name", name)
+        except (TypeError, AttributeError) as e:
+            self.ise.fail_json(
+                msg=(
+                    "An error occured when executing operation."
+                    " Check the configuration of your API Settings and API Gateway settings on your ISE server."
+                    " This collection assumes that the API Gateway, the ERS APIs and OpenAPIs are enabled."
+                    " You may want to enable the (ise_debug: True) argument."
+                    " The error was: {error}"
+                ).format(error=e)
+            )
+        except Exception:
+            result = None
+        return result
+
+    def get_object_by_id(self, id):
+        # NOTICE: Does not have a get by id method or it is in another action
+        result = None
+        return result
+
+    def exists(self):
+        prev_obj = None
+        id_exists = False
+        name_exists = False
+        o_id = self.new_object.get("id")
+        name = self.new_object.get("hostname")
+        if o_id:
+            prev_obj = self.get_object_by_id(o_id)
+            id_exists = prev_obj is not None and isinstance(prev_obj, dict)
+        if not id_exists and name:
+            prev_obj = self.get_object_by_name(name)
+            name_exists = prev_obj is not None and isinstance(prev_obj, dict)
+        if name_exists:
+            _id = prev_obj.get("id")
+            if id_exists and name_exists and o_id != _id:
+                raise InconsistentParameters(
+                    "The 'id' and 'name' params don't refer to the same object"
+                )
+        it_exists = prev_obj is not None and isinstance(prev_obj, dict)
+        return (it_exists, prev_obj)
+
+    def requires_update(self, current_obj):
+        if "Standalone" in current_obj.roles:
+            return True
+        return False
 
 
 class ActionModule(ActionBase):
@@ -56,6 +127,10 @@ class ActionModule(ActionBase):
         if not valid:
             raise AnsibleActionFail(errors)
 
+    def get_object(self, params):
+        new_object = dict()
+        return new_object
+
     def run(self, tmp=None, task_vars=None):
         self._task.diff = False
         self._result = super(ActionModule, self).run(tmp, task_vars)
@@ -63,14 +138,30 @@ class ActionModule(ActionBase):
         self._check_argspec()
 
         ise = ISESDK(params=self._task.args)
+        obj = NodeStandaloneToPrimary(self._task.args, ise)
 
-        response = ise.exec(
-            family="node_deployment",
-            function="make_primary",
-            params={},
-        ).response
+        name = self._task.args.get("hostname")
+
+        response = None
+        (obj_exists, prev_obj) = obj.exists()
+        if obj_exists:
+            if obj.requires_update(prev_obj):
+                response = ise.exec(
+                    family="node_deployment",
+                    function="make_primary",
+                    params=self.get_object(self._task.args),
+                ).response
+                ise.object_updated()
+            else:
+                if "PrimaryAdmin" in prev_obj.roles:
+                    ise.result["result"] = "Node is already Primary"
+                else:
+                    ise.fail_json("Invoke this API on Standalone Node only")
+        else:
+            ise.fail_json(
+                "No such HostConfig with hostName [{hostname}]".format(hostname=name)
+            )
 
         self._result.update(dict(ise_response=response))
-        self._result["changed"] = True
         self._result.update(ise.exit_json())
         return self._result

--- a/plugins/action/node_standalone_to_primary.py
+++ b/plugins/action/node_standalone_to_primary.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2024, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+from ansible.plugins.action import ActionBase
+try:
+    from ansible_collections.ansible.utils.plugins.module_utils.common.argspec_validate import (
+        AnsibleArgSpecValidator,
+    )
+except ImportError:
+    ANSIBLE_UTILS_IS_INSTALLED = False
+else:
+    ANSIBLE_UTILS_IS_INSTALLED = True
+from ansible.errors import AnsibleActionFail
+from ansible_collections.cisco.ise.plugins.plugin_utils.ise import (
+    ISESDK,
+    ise_argument_spec,
+)
+
+argument_spec = ise_argument_spec()
+
+required_if = []
+required_one_of = []
+mutually_exclusive = []
+required_together = []
+
+
+class ActionModule(ActionBase):
+    def __init__(self, *args, **kwargs):
+        if not ANSIBLE_UTILS_IS_INSTALLED:
+            raise AnsibleActionFail(
+                "ansible.utils is not installed. Execute 'ansible-galaxy collection install ansible.utils'"
+            )
+        super(ActionModule, self).__init__(*args, **kwargs)
+        self._supports_async = False
+        self._supports_check_mode = False
+        self._result = None
+
+    def _check_argspec(self):
+        aav = AnsibleArgSpecValidator(
+            data=self._task.args,
+            schema=dict(argument_spec=argument_spec),
+            schema_format="argspec",
+            schema_conditionals=dict(
+                required_if=required_if,
+                required_one_of=required_one_of,
+                mutually_exclusive=mutually_exclusive,
+                required_together=required_together,
+            ),
+            name=self._task.action,
+        )
+        valid, errors, self._task.args = aav.validate()
+        if not valid:
+            raise AnsibleActionFail(errors)
+
+    def run(self, tmp=None, task_vars=None):
+        self._task.diff = False
+        self._result = super(ActionModule, self).run(tmp, task_vars)
+        self._result["changed"] = False
+        self._check_argspec()
+
+        ise = ISESDK(params=self._task.args)
+
+        response = ise.exec(
+            family="node_deployment",
+            function="make_primary",
+            params={},
+        ).response
+
+        self._result.update(dict(ise_response=response))
+        self._result["changed"] = True
+        self._result.update(ise.exit_json())
+        return self._result

--- a/plugins/action/pan_ha.py
+++ b/plugins/action/pan_ha.py
@@ -113,19 +113,18 @@ class PanHa(object):
     def create(self):
         result = self.ise.exec(
             family="pan_ha",
-            function="enable_pan_ha",
+            function="update_pan_ha",
             params=self.new_object,
         ).response
         return result
 
     def delete(self):
-        id = self.new_object.get("id")
-        name = self.new_object.get("name")
-        result = None
+        params = dict(self.new_object)
+        params['is_enabled'] = False
         result = self.ise.exec(
             family="pan_ha",
-            function="disable_pan_ha",
-            params=self.new_object
+            function="update_pan_ha",
+            params=params,
         ).response
         return result
 

--- a/plugins/modules/active_directory_add_groups.py
+++ b/plugins/modules/active_directory_add_groups.py
@@ -1,0 +1,92 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: active_directory_add_groups
+short_description: Resource module for Active Directory Add Groups
+description:
+  - Add AD groups to the Cisco ISE Active Directory configuration.
+version_added: '1.0.0'
+extends_documentation_fragment:
+  - cisco.ise.module_info
+author: Rafael Campos (@racampos)
+options:
+  id:
+    description:
+      - Id path parameter. ID of the Active Directory configuration.
+    type: str
+    required: true
+  adAttributes:
+    description:
+      - AD attributes configuration.
+    type: dict
+  adScopesNames:
+    description:
+      - Comma-separated list of Active Directory scopes.
+    type: str
+  adgroups:
+    description:
+      - AD groups to add. Contains the groups dict with group entries.
+    type: dict
+  advancedSettings:
+    description:
+      - Advanced settings for the Active Directory configuration.
+    type: dict
+  description:
+    description:
+      - Description of the Active Directory configuration.
+    type: str
+  domain:
+    description:
+      - Active Directory domain name.
+    type: str
+  enableDomainAllowedList:
+    description:
+      - Enable domain allowed list.
+    type: bool
+  ERSActiveDirectoryDomains:
+    description:
+      - ERS Active Directory domains configuration.
+    type: dict
+  name:
+    description:
+      - Name of the Active Directory configuration.
+    type: str
+requirements:
+  - ciscoisesdk >= 2.2.1
+  - python >= 3.5
+notes:
+  - SDK Method used are
+    active_directory.ActiveDirectory.update_activedirectory_addgroups_by_id,
+  - Paths used are
+    put /ers/config/activedirectory/{id}/addGroups,
+"""
+
+EXAMPLES = r"""
+---
+- name: Add AD groups to ISE Active Directory configuration
+  cisco.ise.active_directory_add_groups:
+    ise_hostname: "{{ise_hostname}}"
+    ise_username: "{{ise_username}}"
+    ise_password: "{{ise_password}}"
+    ise_verify: "{{ise_verify}}"
+    id: "{{ad_config_id}}"
+    adgroups:
+      groups:
+        - name: CORP\\Domain Users
+          sid: S-1-5-21-...
+          type: BUILT_IN
+  register: result
+"""
+
+RETURN = r"""
+ise_response:
+  description: A dictionary or list with the response returned by the Cisco ISE Python SDK
+  returned: always
+  type: dict
+  sample: >
+    {}
+"""

--- a/plugins/modules/active_directory_groups_by_domain_info.py
+++ b/plugins/modules/active_directory_groups_by_domain_info.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: active_directory_groups_by_domain_info
+short_description: Information module for Active Directory Groups By Domain
+description:
+  - Get Active Directory groups for a specific domain.
+version_added: '1.0.0'
+extends_documentation_fragment:
+  - cisco.ise.module_info
+author: Rafael Campos (@racampos)
+options:
+  id:
+    description:
+      - Id path parameter. ID of the Active Directory configuration.
+    type: str
+    required: true
+  additionalData:
+    description:
+      - List of name/value pairs to filter the domain groups query.
+        Typical entries include domain, username, and password.
+      - "Example: [{name: domain, value: CORP.EXAMPLE.COM},
+        {name: username, value: jdoe}, {name: password, value: secret}]"
+    type: list
+    elements: dict
+requirements:
+  - ciscoisesdk >= 2.2.1
+  - python >= 3.5
+notes:
+  - SDK Method used are
+    active_directory.ActiveDirectory.update_activedirectory_getgroupsbydomain_by_id,
+  - Paths used are
+    put /ers/config/activedirectory/{id}/getGroupsByDomain,
+"""
+
+EXAMPLES = r"""
+---
+- name: Get AD groups by domain
+  cisco.ise.active_directory_groups_by_domain_info:
+    ise_hostname: "{{ise_hostname}}"
+    ise_username: "{{ise_username}}"
+    ise_password: "{{ise_password}}"
+    ise_verify: "{{ise_verify}}"
+    id: "{{ad_config_id}}"
+    additionalData:
+      - name: domain
+        value: CORP.EXAMPLE.COM
+      - name: username
+        value: jdoe
+      - name: password
+        value: "{{domain_password}}"
+  register: result
+"""
+
+RETURN = r"""
+ise_response:
+  description: A dictionary or list with the response returned by the Cisco ISE Python SDK
+  returned: always
+  type: dict
+  sample: >
+    {
+      "ERSActiveDirectoryGroups": {
+        "groups": [
+          {
+            "name": "string",
+            "sid": "string",
+            "type": "string"
+          }
+        ]
+      }
+    }
+"""

--- a/plugins/modules/active_directory_join_domain.py
+++ b/plugins/modules/active_directory_join_domain.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: active_directory_join_domain
+short_description: Resource module for Active Directory Join Domain
+description:
+  - Join a Cisco ISE node to an Active Directory domain.
+version_added: '1.0.0'
+extends_documentation_fragment:
+  - cisco.ise.module_info
+author: Rafael Campos (@racampos)
+options:
+  id:
+    description:
+      - Id path parameter. ID of the Active Directory configuration.
+    type: str
+    required: true
+  adAttributes:
+    description:
+      - AD attributes configuration.
+    type: dict
+  adScopesNames:
+    description:
+      - Comma-separated list of Active Directory scopes.
+    type: str
+  adgroups:
+    description:
+      - AD groups configuration.
+    type: dict
+  advancedSettings:
+    description:
+      - Advanced settings for the Active Directory join.
+    type: dict
+  description:
+    description:
+      - Description of the Active Directory configuration.
+    type: str
+  domain:
+    description:
+      - Active Directory domain to join.
+    type: str
+  enableDomainAllowedList:
+    description:
+      - Enable domain allowed list.
+    type: bool
+  ERSActiveDirectoryDomains:
+    description:
+      - ERS Active Directory domains configuration.
+    type: dict
+  name:
+    description:
+      - Name of the Active Directory configuration.
+    type: str
+requirements:
+  - ciscoisesdk >= 2.2.1
+  - python >= 3.5
+notes:
+  - SDK Method used are
+    active_directory.ActiveDirectory.update_activedirectory_join_by_id,
+  - Paths used are
+    put /ers/config/activedirectory/{id}/join,
+"""
+
+EXAMPLES = r"""
+---
+- name: Join ISE node to Active Directory domain
+  cisco.ise.active_directory_join_domain:
+    ise_hostname: "{{ise_hostname}}"
+    ise_username: "{{ise_username}}"
+    ise_password: "{{ise_password}}"
+    ise_verify: "{{ise_verify}}"
+    id: "{{ad_config_id}}"
+    domain: CORP.EXAMPLE.COM
+  register: result
+"""
+
+RETURN = r"""
+ise_response:
+  description: A dictionary or list with the response returned by the Cisco ISE Python SDK
+  returned: always
+  type: dict
+  sample: >
+    {}
+"""

--- a/plugins/modules/active_directory_leave_domain.py
+++ b/plugins/modules/active_directory_leave_domain.py
@@ -1,0 +1,87 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: active_directory_leave_domain
+short_description: Resource module for Active Directory Leave Domain
+description:
+  - Remove a Cisco ISE node from an Active Directory domain.
+version_added: '1.0.0'
+extends_documentation_fragment:
+  - cisco.ise.module_info
+author: Rafael Campos (@racampos)
+options:
+  id:
+    description:
+      - Id path parameter. ID of the Active Directory configuration.
+    type: str
+    required: true
+  adAttributes:
+    description:
+      - AD attributes configuration.
+    type: dict
+  adScopesNames:
+    description:
+      - Comma-separated list of Active Directory scopes.
+    type: str
+  adgroups:
+    description:
+      - AD groups configuration.
+    type: dict
+  advancedSettings:
+    description:
+      - Advanced settings for the Active Directory leave operation.
+    type: dict
+  description:
+    description:
+      - Description of the Active Directory configuration.
+    type: str
+  domain:
+    description:
+      - Active Directory domain to leave.
+    type: str
+  enableDomainAllowedList:
+    description:
+      - Enable domain allowed list.
+    type: bool
+  ERSActiveDirectoryDomains:
+    description:
+      - ERS Active Directory domains configuration.
+    type: dict
+  name:
+    description:
+      - Name of the Active Directory configuration.
+    type: str
+requirements:
+  - ciscoisesdk >= 2.2.1
+  - python >= 3.5
+notes:
+  - SDK Method used are
+    active_directory.ActiveDirectory.update_activedirectory_leave_by_id,
+  - Paths used are
+    put /ers/config/activedirectory/{id}/leave,
+"""
+
+EXAMPLES = r"""
+---
+- name: Leave Active Directory domain
+  cisco.ise.active_directory_leave_domain:
+    ise_hostname: "{{ise_hostname}}"
+    ise_username: "{{ise_username}}"
+    ise_password: "{{ise_password}}"
+    ise_verify: "{{ise_verify}}"
+    id: "{{ad_config_id}}"
+  register: result
+"""
+
+RETURN = r"""
+ise_response:
+  description: A dictionary or list with the response returned by the Cisco ISE Python SDK
+  returned: always
+  type: dict
+  sample: >
+    {}
+"""

--- a/plugins/modules/node_deployment.py
+++ b/plugins/modules/node_deployment.py
@@ -1,0 +1,150 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: node_deployment
+short_description: Resource module for Node Deployment
+description:
+  - Manage operations create, update and delete of the resource Node Deployment.
+  - Register a new ISE node, update node roles/services, or deregister a node.
+version_added: '1.0.0'
+extends_documentation_fragment:
+  - cisco.ise.module
+author: Rafael Campos (@racampos)
+options:
+  state:
+    description:
+      - The state of the resource.
+    type: str
+    default: present
+    choices: [present, absent]
+  hostname:
+    description:
+      - Hostname of the ISE node. Used as primary identifier.
+    type: str
+  allowCertImport:
+    description:
+      - Allow the import of self-signed certificates from the node being registered.
+    type: bool
+  fqdn:
+    description:
+      - Fully qualified domain name of the node being registered.
+    type: str
+  password:
+    description:
+      - Password for the node admin account. Required on create.
+    type: str
+  roles:
+    description:
+      - ISE roles to assign to the node (e.g. PrimaryAdmin, SecondaryAdmin, PrimaryMonitoring).
+    type: list
+    elements: str
+  services:
+    description:
+      - ISE services to enable on the node (e.g. Session, Profiler, DeviceAdmin).
+    type: list
+    elements: str
+  userName:
+    description:
+      - Admin username for the node being registered. Required on create.
+    type: str
+requirements:
+  - ciscoisesdk >= 2.2.1
+  - python >= 3.5
+notes:
+  - SDK Method used are
+    node_deployment.NodeDeployment.register_node,
+    node_deployment.NodeDeployment.update_node,
+    node_deployment.NodeDeployment.delete_node,
+    node_deployment.NodeDeployment.get_node_details,
+  - Paths used are
+    post /api/v1/deployment/node,
+    put /api/v1/deployment/node/{hostname},
+    delete /api/v1/deployment/node/{hostname},
+    get /api/v1/deployment/node/{hostname},
+"""
+
+EXAMPLES = r"""
+---
+- name: Register a new ISE node
+  cisco.ise.node_deployment:
+    ise_hostname: "{{ise_hostname}}"
+    ise_username: "{{ise_username}}"
+    ise_password: "{{ise_password}}"
+    ise_verify: "{{ise_verify}}"
+    state: present
+    fqdn: isenode.example.com
+    hostname: isenode
+    password: NodeAdminPass123
+    userName: admin
+    roles:
+      - SecondaryAdmin
+    services:
+      - Session
+      - Profiler
+  register: result
+
+- name: Update node roles
+  cisco.ise.node_deployment:
+    ise_hostname: "{{ise_hostname}}"
+    ise_username: "{{ise_username}}"
+    ise_password: "{{ise_password}}"
+    ise_verify: "{{ise_verify}}"
+    state: present
+    hostname: isenode
+    roles:
+      - SecondaryAdmin
+      - SecondaryMonitoring
+    services:
+      - Session
+
+- name: Deregister a node
+  cisco.ise.node_deployment:
+    ise_hostname: "{{ise_hostname}}"
+    ise_username: "{{ise_username}}"
+    ise_password: "{{ise_password}}"
+    ise_verify: "{{ise_verify}}"
+    state: absent
+    hostname: isenode
+"""
+
+RETURN = r"""
+ise_response:
+  description: A dictionary or list with the response returned by the Cisco ISE Python SDK
+  returned: always
+  type: dict
+  sample: >
+    {
+      "hostname": "string",
+      "fqdn": "string",
+      "ipAddress": "string",
+      "nodeServiceTypes": "string",
+      "roles": ["string"],
+      "services": ["string"]
+    }
+ise_update_response:
+  description: A dictionary with the response returned by the Cisco ISE Python SDK
+  returned: always, on update
+  type: dict
+  sample: >
+    {
+      "success": {
+        "message": "string"
+      },
+      "version": "string"
+    }
+ise_create_response:
+  description: A dictionary with the response returned by the Cisco ISE Python SDK
+  returned: always, on create
+  type: dict
+  sample: >
+    {
+      "success": {
+        "message": "string"
+      },
+      "version": "string"
+    }
+"""

--- a/plugins/modules/node_deployment_info.py
+++ b/plugins/modules/node_deployment_info.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: node_deployment_info
+short_description: Information module for Node Deployment
+description:
+  - Get all Node Deployment.
+  - Get Node Deployment by hostname.
+version_added: '1.0.0'
+extends_documentation_fragment:
+  - cisco.ise.module_info
+author: Rafael Campos (@racampos)
+options:
+  hostname:
+    description:
+      - Hostname path parameter.
+    type: str
+  filter:
+    description:
+      - Filter query parameter.
+    type: str
+  filterType:
+    description:
+      - FilterType query parameter.
+    type: str
+requirements:
+  - ciscoisesdk >= 2.2.1
+  - python >= 3.5
+notes:
+  - SDK Method used are
+    node_deployment.NodeDeployment.get_node_details,
+    node_deployment.NodeDeployment.get_deployment_nodes,
+  - Paths used are
+    get /api/v1/deployment/node/{hostname},
+    get /api/v1/deployment/node,
+"""
+
+EXAMPLES = r"""
+---
+- name: Get all Node Deployment
+  cisco.ise.node_deployment_info:
+    ise_hostname: "{{ise_hostname}}"
+    ise_username: "{{ise_username}}"
+    ise_password: "{{ise_password}}"
+    ise_verify: "{{ise_verify}}"
+  register: result
+
+- name: Get Node Deployment by hostname
+  cisco.ise.node_deployment_info:
+    ise_hostname: "{{ise_hostname}}"
+    ise_username: "{{ise_username}}"
+    ise_password: "{{ise_password}}"
+    ise_verify: "{{ise_verify}}"
+    hostname: isenode.example.com
+  register: result
+"""
+
+RETURN = r"""
+ise_response:
+  description: A dictionary or list with the response returned by the Cisco ISE Python SDK
+  returned: always
+  type: dict
+  sample: >
+    {
+      "hostname": "string",
+      "fqdn": "string",
+      "ipAddress": "string",
+      "nodeServiceTypes": "string",
+      "roles": ["string"],
+      "services": ["string"]
+    }
+"""

--- a/plugins/modules/node_deployment_sync.py
+++ b/plugins/modules/node_deployment_sync.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: node_deployment_sync
+short_description: Resource module for Node Deployment Sync
+description:
+  - Trigger configuration sync on a specific ISE node by hostname.
+version_added: '1.0.0'
+extends_documentation_fragment:
+  - cisco.ise.module_info
+author: Rafael Campos (@racampos)
+options:
+  hostname:
+    description:
+      - Hostname path parameter. FQDN of the ISE node to sync.
+    type: str
+    required: true
+requirements:
+  - ciscoisesdk >= 2.2.1
+  - python >= 3.5
+notes:
+  - SDK Method used are
+    node_deployment.NodeDeployment.sync_node,
+  - Paths used are
+    post /api/v1/deployment/sync-node/{hostname},
+"""
+
+EXAMPLES = r"""
+---
+- name: Sync Node Deployment
+  cisco.ise.node_deployment_sync:
+    ise_hostname: "{{ise_hostname}}"
+    ise_username: "{{ise_username}}"
+    ise_password: "{{ise_password}}"
+    ise_verify: "{{ise_verify}}"
+    hostname: isenode.example.com
+  register: result
+"""
+
+RETURN = r"""
+ise_response:
+  description: A dictionary or list with the response returned by the Cisco ISE Python SDK
+  returned: always
+  type: dict
+  sample: >
+    {
+      "success": {
+        "message": "string"
+      },
+      "version": "string"
+    }
+"""

--- a/plugins/modules/node_group.py
+++ b/plugins/modules/node_group.py
@@ -1,0 +1,146 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: node_group
+short_description: Resource module for Node Group
+description:
+  - Manage operations create, update and delete of the resource Node Group.
+version_added: '1.0.0'
+extends_documentation_fragment:
+  - cisco.ise.module
+author: Rafael Campos (@racampos)
+options:
+  state:
+    description:
+      - The state of the resource.
+    type: str
+    default: present
+    choices: [present, absent]
+  nodeGroupName:
+    description:
+      - NodeGroupName path parameter. Name of the existing node group (used for update/delete).
+    type: str
+  name:
+    description:
+      - Name of the node group to create.
+    type: str
+  description:
+    description:
+      - Description of the node group.
+    type: str
+  marCache:
+    description:
+      - MAR (Machine Access Restriction) cache settings for the node group.
+    type: dict
+    suboptions:
+      query-attempts:
+        description: Number of query attempts.
+        type: int
+      query-timeout:
+        description: Query timeout in seconds.
+        type: int
+      replication-attempts:
+        description: Number of replication attempts.
+        type: int
+      replication-timeout:
+        description: Replication timeout in seconds.
+        type: int
+  forceDelete:
+    description:
+      - Force deletion even if the node group has nodes assigned.
+    type: bool
+    default: false
+requirements:
+  - ciscoisesdk >= 2.2.1
+  - python >= 3.5
+notes:
+  - SDK Method used are
+    node_group.NodeGroup.create_node_group,
+    node_group.NodeGroup.update_node_group,
+    node_group.NodeGroup.delete_node_group,
+    node_group.NodeGroup.get_node_group,
+    node_group.NodeGroup.get_node_groups,
+  - Paths used are
+    post /api/v1/deployment/node-group,
+    put /api/v1/deployment/node-group/{nodeGroupName},
+    delete /api/v1/deployment/node-group/{nodeGroupName},
+    get /api/v1/deployment/node-group/{nodeGroupName},
+    get /api/v1/deployment/node-group,
+"""
+
+EXAMPLES = r"""
+---
+- name: Create a node group
+  cisco.ise.node_group:
+    ise_hostname: "{{ise_hostname}}"
+    ise_username: "{{ise_username}}"
+    ise_password: "{{ise_password}}"
+    ise_verify: "{{ise_verify}}"
+    state: present
+    name: mygroup
+    description: My ISE node group
+
+- name: Update a node group description
+  cisco.ise.node_group:
+    ise_hostname: "{{ise_hostname}}"
+    ise_username: "{{ise_username}}"
+    ise_password: "{{ise_password}}"
+    ise_verify: "{{ise_verify}}"
+    state: present
+    nodeGroupName: mygroup
+    description: Updated description
+
+- name: Delete a node group
+  cisco.ise.node_group:
+    ise_hostname: "{{ise_hostname}}"
+    ise_username: "{{ise_username}}"
+    ise_password: "{{ise_password}}"
+    ise_verify: "{{ise_verify}}"
+    state: absent
+    nodeGroupName: mygroup
+    forceDelete: false
+"""
+
+RETURN = r"""
+ise_response:
+  description: A dictionary or list with the response returned by the Cisco ISE Python SDK
+  returned: always
+  type: dict
+  sample: >
+    {
+      "description": "string",
+      "marCache": {
+        "query-attempts": 0,
+        "query-timeout": 0,
+        "replication-attempts": 0,
+        "replication-timeout": 0
+      },
+      "name": "string"
+    }
+ise_update_response:
+  description: A dictionary with the update response from the Cisco ISE Python SDK
+  returned: always, on update
+  type: dict
+  sample: >
+    {
+      "success": {
+        "message": "string"
+      },
+      "version": "string"
+    }
+ise_create_response:
+  description: A dictionary with the create response from the Cisco ISE Python SDK
+  returned: always, on create
+  type: dict
+  sample: >
+    {
+      "success": {
+        "message": "string"
+      },
+      "version": "string"
+    }
+"""

--- a/plugins/modules/node_group_info.py
+++ b/plugins/modules/node_group_info.py
@@ -1,0 +1,70 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: node_group_info
+short_description: Information module for Node Group
+description:
+  - Get all Node Groups.
+  - Get Node Group by name.
+version_added: '1.0.0'
+extends_documentation_fragment:
+  - cisco.ise.module_info
+author: Rafael Campos (@racampos)
+options:
+  nodeGroupName:
+    description:
+      - NodeGroupName path parameter. Name of the node group.
+    type: str
+requirements:
+  - ciscoisesdk >= 2.2.1
+  - python >= 3.5
+notes:
+  - SDK Method used are
+    node_group.NodeGroup.get_node_groups,
+    node_group.NodeGroup.get_node_group,
+  - Paths used are
+    get /api/v1/deployment/node-group,
+    get /api/v1/deployment/node-group/{nodeGroupName},
+"""
+
+EXAMPLES = r"""
+---
+- name: Get all Node Groups
+  cisco.ise.node_group_info:
+    ise_hostname: "{{ise_hostname}}"
+    ise_username: "{{ise_username}}"
+    ise_password: "{{ise_password}}"
+    ise_verify: "{{ise_verify}}"
+  register: result
+
+- name: Get Node Group by name
+  cisco.ise.node_group_info:
+    ise_hostname: "{{ise_hostname}}"
+    ise_username: "{{ise_username}}"
+    ise_password: "{{ise_password}}"
+    ise_verify: "{{ise_verify}}"
+    nodeGroupName: mygroup
+  register: result
+"""
+
+RETURN = r"""
+ise_response:
+  description: A dictionary or list with the response returned by the Cisco ISE Python SDK
+  returned: always
+  type: dict
+  sample: >
+    {
+      "description": "string",
+      "marCache": {
+        "query-attempts": 0,
+        "query-timeout": 0,
+        "replication-attempts": 0,
+        "replication-timeout": 0
+      },
+      "name": "string"
+    }
+"""

--- a/plugins/modules/node_group_node_create.py
+++ b/plugins/modules/node_group_node_create.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: node_group_node_create
+short_description: Resource module for Node Group Node Create
+description:
+  - Add a node to a node group.
+version_added: '1.0.0'
+extends_documentation_fragment:
+  - cisco.ise.module_info
+author: Rafael Campos (@racampos)
+options:
+  nodeGroupName:
+    description:
+      - NodeGroupName path parameter. Name of the node group.
+    type: str
+    required: true
+  hostname:
+    description:
+      - Hostname of the ISE node to add to the group.
+    type: str
+    required: true
+requirements:
+  - ciscoisesdk >= 2.2.1
+  - python >= 3.5
+notes:
+  - SDK Method used are
+    node_group.NodeGroup.add_node,
+  - Paths used are
+    post /api/v1/deployment/node-group/{nodeGroupName}/add-node,
+"""
+
+EXAMPLES = r"""
+---
+- name: Add node to node group
+  cisco.ise.node_group_node_create:
+    ise_hostname: "{{ise_hostname}}"
+    ise_username: "{{ise_username}}"
+    ise_password: "{{ise_password}}"
+    ise_verify: "{{ise_verify}}"
+    nodeGroupName: mygroup
+    hostname: isenode.example.com
+  register: result
+"""
+
+RETURN = r"""
+ise_response:
+  description: A dictionary or list with the response returned by the Cisco ISE Python SDK
+  returned: always
+  type: dict
+  sample: >
+    {
+      "success": {
+        "message": "string"
+      },
+      "version": "string"
+    }
+"""

--- a/plugins/modules/node_group_node_delete.py
+++ b/plugins/modules/node_group_node_delete.py
@@ -1,0 +1,62 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: node_group_node_delete
+short_description: Resource module for Node Group Node Delete
+description:
+  - Remove a node from a node group.
+version_added: '1.0.0'
+extends_documentation_fragment:
+  - cisco.ise.module_info
+author: Rafael Campos (@racampos)
+options:
+  nodeGroupName:
+    description:
+      - NodeGroupName path parameter. Name of the node group.
+    type: str
+    required: true
+  hostname:
+    description:
+      - Hostname of the ISE node to remove from the group.
+    type: str
+    required: true
+requirements:
+  - ciscoisesdk >= 2.2.1
+  - python >= 3.5
+notes:
+  - SDK Method used are
+    node_group.NodeGroup.remove_node,
+  - Paths used are
+    post /api/v1/deployment/node-group/{nodeGroupName}/remove-node,
+"""
+
+EXAMPLES = r"""
+---
+- name: Remove node from node group
+  cisco.ise.node_group_node_delete:
+    ise_hostname: "{{ise_hostname}}"
+    ise_username: "{{ise_username}}"
+    ise_password: "{{ise_password}}"
+    ise_verify: "{{ise_verify}}"
+    nodeGroupName: mygroup
+    hostname: isenode.example.com
+  register: result
+"""
+
+RETURN = r"""
+ise_response:
+  description: A dictionary or list with the response returned by the Cisco ISE Python SDK
+  returned: always
+  type: dict
+  sample: >
+    {
+      "success": {
+        "message": "string"
+      },
+      "version": "string"
+    }
+"""

--- a/plugins/modules/node_group_node_info.py
+++ b/plugins/modules/node_group_node_info.py
@@ -1,0 +1,56 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: node_group_node_info
+short_description: Information module for Node Group Node
+description:
+  - Get all nodes belonging to a node group.
+version_added: '1.0.0'
+extends_documentation_fragment:
+  - cisco.ise.module_info
+author: Rafael Campos (@racampos)
+options:
+  nodeGroupName:
+    description:
+      - NodeGroupName path parameter. Name of the node group.
+    type: str
+    required: true
+requirements:
+  - ciscoisesdk >= 2.2.1
+  - python >= 3.5
+notes:
+  - SDK Method used are
+    node_group.NodeGroup.get_nodes,
+  - Paths used are
+    get /api/v1/deployment/node-group/{nodeGroupName}/node,
+"""
+
+EXAMPLES = r"""
+---
+- name: Get nodes in a node group
+  cisco.ise.node_group_node_info:
+    ise_hostname: "{{ise_hostname}}"
+    ise_username: "{{ise_username}}"
+    ise_password: "{{ise_password}}"
+    ise_verify: "{{ise_verify}}"
+    nodeGroupName: mygroup
+  register: result
+"""
+
+RETURN = r"""
+ise_response:
+  description: A dictionary or list with the response returned by the Cisco ISE Python SDK
+  returned: always
+  type: list
+  elements: dict
+  sample: >
+    [
+      {
+        "hostname": "string"
+      }
+    ]
+"""

--- a/plugins/modules/node_secondary_to_primary.py
+++ b/plugins/modules/node_secondary_to_primary.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: node_secondary_to_primary
+short_description: Resource module for Node Secondary To Primary
+description:
+  - Promote a secondary PAN node to primary PAN.
+version_added: '1.0.0'
+extends_documentation_fragment:
+  - cisco.ise.module_info
+author: Rafael Campos (@racampos)
+options: {}
+requirements:
+  - ciscoisesdk >= 2.2.1
+  - python >= 3.5
+notes:
+  - SDK Method used are
+    node_deployment.NodeDeployment.promote_node,
+  - Paths used are
+    post /api/v1/deployment/promote,
+"""
+
+EXAMPLES = r"""
+---
+- name: Promote secondary PAN to primary
+  cisco.ise.node_secondary_to_primary:
+    ise_hostname: "{{ise_hostname}}"
+    ise_username: "{{ise_username}}"
+    ise_password: "{{ise_password}}"
+    ise_verify: "{{ise_verify}}"
+  register: result
+"""
+
+RETURN = r"""
+ise_response:
+  description: A dictionary or list with the response returned by the Cisco ISE Python SDK
+  returned: always
+  type: dict
+  sample: >
+    {
+      "success": {
+        "message": "string"
+      },
+      "version": "string"
+    }
+"""

--- a/plugins/modules/node_services_profiler_probe_config.py
+++ b/plugins/modules/node_services_profiler_probe_config.py
@@ -56,12 +56,14 @@ options:
     elements: dict
   pxgrid:
     description:
-      - Enable or disable pxGrid probe.
-    type: bool
+      - PxGrid probe configuration list.
+    type: list
+    elements: dict
   radius:
     description:
-      - RADIUS probe configuration.
-    type: dict
+      - RADIUS probe configuration list.
+    type: list
+    elements: dict
   snmpQuery:
     description:
       - SNMP query probe configuration.

--- a/plugins/modules/node_services_profiler_probe_config.py
+++ b/plugins/modules/node_services_profiler_probe_config.py
@@ -1,0 +1,114 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: node_services_profiler_probe_config
+short_description: Resource module for Node Services Profiler Probe Config
+description:
+  - Set profiler probe configuration for a specific ISE node.
+version_added: '1.0.0'
+extends_documentation_fragment:
+  - cisco.ise.module
+author: Rafael Campos (@racampos)
+options:
+  state:
+    description:
+      - The state of the resource.
+    type: str
+    default: present
+    choices: [present]
+  hostname:
+    description:
+      - Hostname path parameter. FQDN or hostname of the ISE node.
+    type: str
+    required: true
+  activeDirectory:
+    description:
+      - Active Directory probe configuration.
+    type: dict
+  dhcp:
+    description:
+      - DHCP probe configuration.
+    type: dict
+  dhcpSpan:
+    description:
+      - DHCP SPAN probe configuration.
+    type: dict
+  dns:
+    description:
+      - DNS probe configuration.
+    type: dict
+  http:
+    description:
+      - HTTP probe configuration.
+    type: dict
+  netflow:
+    description:
+      - NetFlow probe configuration.
+    type: dict
+  nmap:
+    description:
+      - NMAP probe configuration list.
+    type: list
+    elements: dict
+  pxgrid:
+    description:
+      - Enable or disable pxGrid probe.
+    type: bool
+  radius:
+    description:
+      - RADIUS probe configuration.
+    type: dict
+  snmpQuery:
+    description:
+      - SNMP query probe configuration.
+    type: dict
+  snmpTrap:
+    description:
+      - SNMP trap probe configuration.
+    type: dict
+requirements:
+  - ciscoisesdk >= 2.2.1
+  - python >= 3.5
+notes:
+  - SDK Method used are
+    node_services.NodeServices.set_profiler_probe_config,
+  - Paths used are
+    put /api/v1/profile/{hostname},
+"""
+
+EXAMPLES = r"""
+---
+- name: Set profiler probe configuration
+  cisco.ise.node_services_profiler_probe_config:
+    ise_hostname: "{{ise_hostname}}"
+    ise_username: "{{ise_username}}"
+    ise_password: "{{ise_password}}"
+    ise_verify: "{{ise_verify}}"
+    hostname: isenode.example.com
+    dhcp:
+      interfaces:
+        - interface: GigabitEthernet0
+      port: 67
+    dns:
+      timeout: 2
+    pxgrid: false
+  register: result
+"""
+
+RETURN = r"""
+ise_response:
+  description: A dictionary or list with the response returned by the Cisco ISE Python SDK
+  returned: always
+  type: dict
+  sample: >
+    {
+      "success": {
+        "message": "string"
+      },
+      "version": "string"
+    }
+"""

--- a/plugins/modules/node_services_profiler_probe_config_info.py
+++ b/plugins/modules/node_services_profiler_probe_config_info.py
@@ -1,0 +1,86 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: node_services_profiler_probe_config_info
+short_description: Information module for Node Services Profiler Probe Config
+description:
+  - Get profiler probe configuration for a specific ISE node by hostname.
+version_added: '1.0.0'
+extends_documentation_fragment:
+  - cisco.ise.module_info
+author: Rafael Campos (@racampos)
+options:
+  hostname:
+    description:
+      - Hostname path parameter. FQDN or hostname of the ISE node.
+    type: str
+    required: true
+requirements:
+  - ciscoisesdk >= 2.2.1
+  - python >= 3.5
+notes:
+  - SDK Method used are
+    node_services.NodeServices.get_profiler_probe_config,
+  - Paths used are
+    get /api/v1/profile/{hostname},
+"""
+
+EXAMPLES = r"""
+---
+- name: Get profiler probe configuration for a node
+  cisco.ise.node_services_profiler_probe_config_info:
+    ise_hostname: "{{ise_hostname}}"
+    ise_username: "{{ise_username}}"
+    ise_password: "{{ise_password}}"
+    ise_verify: "{{ise_verify}}"
+    hostname: isenode.example.com
+  register: result
+"""
+
+RETURN = r"""
+ise_response:
+  description: A dictionary or list with the response returned by the Cisco ISE Python SDK
+  returned: always
+  type: dict
+  sample: >
+    {
+      "activeDirectory": {
+        "daysBeforeRescan": 0
+      },
+      "dhcp": {
+        "interfaces": [{"interface": "string"}],
+        "port": 0
+      },
+      "dhcpSpan": {
+        "interfaces": [{"interface": "string"}]
+      },
+      "dns": {
+        "timeout": 0
+      },
+      "http": {
+        "interfaces": [{"interface": "string"}]
+      },
+      "netflow": {
+        "interfaces": [{"interface": "string"}],
+        "port": 0
+      },
+      "nmap": [],
+      "pxgrid": false,
+      "radius": {},
+      "snmpQuery": {
+        "eventTimeout": 0,
+        "retries": 0,
+        "timeout": 0
+      },
+      "snmpTrap": {
+        "interfaces": [{"interface": "string"}],
+        "linkTrapQuery": true,
+        "macTrapQuery": true,
+        "port": 0
+      }
+    }
+"""

--- a/plugins/modules/node_standalone_to_primary.py
+++ b/plugins/modules/node_standalone_to_primary.py
@@ -1,0 +1,50 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+# Copyright (c) 2021, Cisco Systems
+# GNU General Public License v3.0+ (see LICENSE or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: node_standalone_to_primary
+short_description: Resource module for Node Standalone To Primary
+description:
+  - Promote a standalone ISE node to primary PAN.
+version_added: '1.0.0'
+extends_documentation_fragment:
+  - cisco.ise.module_info
+author: Rafael Campos (@racampos)
+options: {}
+requirements:
+  - ciscoisesdk >= 2.2.1
+  - python >= 3.5
+notes:
+  - SDK Method used are
+    node_deployment.NodeDeployment.make_primary,
+  - Paths used are
+    post /api/v1/deployment/primary,
+"""
+
+EXAMPLES = r"""
+---
+- name: Promote standalone node to primary PAN
+  cisco.ise.node_standalone_to_primary:
+    ise_hostname: "{{ise_hostname}}"
+    ise_username: "{{ise_username}}"
+    ise_password: "{{ise_password}}"
+    ise_verify: "{{ise_verify}}"
+  register: result
+"""
+
+RETURN = r"""
+ise_response:
+  description: A dictionary or list with the response returned by the Cisco ISE Python SDK
+  returned: always
+  type: dict
+  sample: >
+    {
+      "success": {
+        "message": "string"
+      },
+      "version": "string"
+    }
+"""


### PR DESCRIPTION
- Introduced `active_directory_add_groups` module for adding AD groups to Cisco ISE.
- Added `active_directory_groups_by_domain_info` module to retrieve AD groups by domain.
- Created `active_directory_join_domain` and `active_directory_leave_domain` modules for joining and leaving AD domains.
- Implemented `node_deployment` module for managing ISE node operations including registration and deregistration.
- Added `node_group` module for creating, updating, and deleting node groups.
- Introduced `node_group_node_create` and `node_group_node_delete` modules for managing nodes within groups.
- Created `node_services_profiler_probe_config` module for configuring profiler probes on ISE nodes.
- Added information modules for retrieving details about node deployments and node groups.